### PR TITLE
Change package name of forked source to reduce clashes

### DIFF
--- a/src/integrationTest/groovy/wooga/gradle/version/VersionPluginIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/version/VersionPluginIntegrationSpec.groovy
@@ -18,7 +18,7 @@
 
 package wooga.gradle.version
 
-import org.ajoberstar.gradle.git.release.semver.ChangeScope
+import wooga.gradle.version.internal.release.semver.ChangeScope
 import spock.lang.Unroll
 
 class VersionPluginIntegrationSpec extends IntegrationSpec {

--- a/src/main/groovy/wooga/gradle/version/VersionPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/version/VersionPlugin.groovy
@@ -17,7 +17,7 @@
 
 package wooga.gradle.version
 
-import org.ajoberstar.gradle.git.release.base.ReleaseVersion
+import wooga.gradle.version.internal.release.base.ReleaseVersion
 import org.ajoberstar.grgit.Grgit
 import org.eclipse.jgit.errors.RepositoryNotFoundException
 import org.gradle.api.Action

--- a/src/main/groovy/wooga/gradle/version/VersionPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/version/VersionPluginExtension.groovy
@@ -18,9 +18,9 @@
 
 package wooga.gradle.version
 
-import org.ajoberstar.gradle.git.release.base.ReleaseVersion
-import org.ajoberstar.gradle.git.release.base.TagStrategy
-import org.ajoberstar.gradle.git.release.semver.ChangeScope
+import wooga.gradle.version.internal.release.base.ReleaseVersion
+import wooga.gradle.version.internal.release.base.TagStrategy
+import wooga.gradle.version.internal.release.semver.ChangeScope
 import org.ajoberstar.grgit.Grgit
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider

--- a/src/main/groovy/wooga/gradle/version/internal/DefaultVersionPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/version/internal/DefaultVersionPluginExtension.groovy
@@ -18,11 +18,11 @@
 
 package wooga.gradle.version.internal
 
-import org.ajoberstar.gradle.git.release.base.DefaultVersionStrategy
-import org.ajoberstar.gradle.git.release.base.ReleaseVersion
-import org.ajoberstar.gradle.git.release.base.TagStrategy
-import org.ajoberstar.gradle.git.release.base.VersionStrategy
-import org.ajoberstar.gradle.git.release.semver.ChangeScope
+import wooga.gradle.version.internal.release.base.DefaultVersionStrategy
+import wooga.gradle.version.internal.release.base.ReleaseVersion
+import wooga.gradle.version.internal.release.base.TagStrategy
+import wooga.gradle.version.internal.release.base.VersionStrategy
+import wooga.gradle.version.internal.release.semver.ChangeScope
 import org.ajoberstar.grgit.Grgit
 import org.gradle.api.GradleException
 import org.gradle.api.Project

--- a/src/main/groovy/wooga/gradle/version/internal/release/base/DefaultVersionStrategy.groovy
+++ b/src/main/groovy/wooga/gradle/version/internal/release/base/DefaultVersionStrategy.groovy
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.ajoberstar.gradle.git.release.base
+package wooga.gradle.version.internal.release.base
 
 import org.ajoberstar.grgit.Grgit
 
@@ -23,8 +23,8 @@ import org.gradle.api.Project
  * Strategy to infer a version from the project's and Git repository's state. This
  * also supports being selected as a default strategy. This is a temporary interface
  * and should be replaced in some other way in gradle-git 2.0.0.
- * @see org.ajoberstar.gradle.git.release.semver.SemVerStrategy
- * @see org.ajoberstar.gradle.git.release.opinion.Strategies
+ * @see wooga.gradle.version.internal.release.semver.SemVerStrategy
+ * @see wooga.gradle.version.internal.release.opinion.Strategies
  */
 interface DefaultVersionStrategy extends VersionStrategy {
     /**

--- a/src/main/groovy/wooga/gradle/version/internal/release/base/ReleaseVersion.groovy
+++ b/src/main/groovy/wooga/gradle/version/internal/release/base/ReleaseVersion.groovy
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.ajoberstar.gradle.git.release.base
+package wooga.gradle.version.internal.release.base
 
 import groovy.transform.Immutable
 

--- a/src/main/groovy/wooga/gradle/version/internal/release/base/TagStrategy.groovy
+++ b/src/main/groovy/wooga/gradle/version/internal/release/base/TagStrategy.groovy
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.ajoberstar.gradle.git.release.base
+package wooga.gradle.version.internal.release.base
 
 import com.github.zafarkhaja.semver.ParseException
 import com.github.zafarkhaja.semver.Version

--- a/src/main/groovy/wooga/gradle/version/internal/release/base/VersionStrategy.groovy
+++ b/src/main/groovy/wooga/gradle/version/internal/release/base/VersionStrategy.groovy
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.ajoberstar.gradle.git.release.base
+package wooga.gradle.version.internal.release.base
 
 import org.ajoberstar.grgit.Grgit
 
@@ -21,8 +21,8 @@ import org.gradle.api.Project
 
 /**
  * Strategy to infer a version from the project's and Git repository's state.
- * @see org.ajoberstar.gradle.git.release.semver.SemVerStrategy
- * @see org.ajoberstar.gradle.git.release.opinion.Strategies
+ * @see wooga.gradle.version.internal.release.semver.SemVerStrategy
+ * @see wooga.gradle.version.internal.release.opinion.Strategies
  */
 interface VersionStrategy {
     /**

--- a/src/main/groovy/wooga/gradle/version/internal/release/opinion/Strategies.groovy
+++ b/src/main/groovy/wooga/gradle/version/internal/release/opinion/Strategies.groovy
@@ -13,25 +13,25 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.ajoberstar.gradle.git.release.opinion
+package wooga.gradle.version.internal.release.opinion
 
-import static org.ajoberstar.gradle.git.release.semver.StrategyUtil.*
+
+import static wooga.gradle.version.internal.release.semver.StrategyUtil.*
 
 import java.util.regex.Pattern
 
-import org.ajoberstar.gradle.git.release.semver.ChangeScope
-import org.ajoberstar.gradle.git.release.semver.PartialSemVerStrategy
-import org.ajoberstar.gradle.git.release.semver.SemVerStrategy
+import wooga.gradle.version.internal.release.semver.PartialSemVerStrategy
+import wooga.gradle.version.internal.release.semver.SemVerStrategy
 
 import org.gradle.api.GradleException
 
 /**
  * Opinionated sample strategies. These can either be used as-is or as an
  * example for others.
- * @see org.ajoberstar.gradle.git.release.base.VersionStrategy
- * @see org.ajoberstar.gradle.git.release.semver.SemVerStrategy
- * @see org.ajoberstar.gradle.git.release.semver.SemVerStrategyState
- * @see org.ajoberstar.gradle.git.release.semver.PartialSemVerStrategy
+ * @see wooga.gradle.version.internal.release.base.VersionStrategy
+ * @see SemVerStrategy
+ * @see wooga.gradle.version.internal.release.semver.SemVerStrategyState
+ * @see PartialSemVerStrategy
  */
 final class Strategies {
     /**
@@ -150,13 +150,13 @@ final class Strategies {
 
                     if (majorDiff == 1 && minor <= 0) {
                         // major is off by one and minor is either 0 or not in the branch name
-                        return incrementNormalFromScope(state, ChangeScope.MAJOR)
+                        return incrementNormalFromScope(state, wooga.gradle.version.internal.release.semver.ChangeScope.MAJOR)
                     } else if (minorDiff == 1 && minor > 0) {
                         // minor is off by one and specified in the branch name
-                        return incrementNormalFromScope(state, ChangeScope.MINOR)
+                        return incrementNormalFromScope(state, wooga.gradle.version.internal.release.semver.ChangeScope.MINOR)
                     } else if (majorDiff == 0 && minorDiff == 0 && minor >= 0) {
                         // major and minor match, both are specified in branch name
-                        return incrementNormalFromScope(state, ChangeScope.PATCH)
+                        return incrementNormalFromScope(state, wooga.gradle.version.internal.release.semver.ChangeScope.PATCH)
                     } else if (majorDiff == 0 && minor < 0) {
                         // only major specified in branch name and already matches
                         return state
@@ -172,7 +172,7 @@ final class Strategies {
         /**
          * Always use the scope provided to increment the normal component.
          */
-        static PartialSemVerStrategy useScope(ChangeScope scope) {
+        static PartialSemVerStrategy useScope(wooga.gradle.version.internal.release.semver.ChangeScope scope) {
             return closure { state -> incrementNormalFromScope(state, scope) }
         }
     }
@@ -280,11 +280,11 @@ final class Strategies {
      * If the {@code release.scope} property is set, use it. Or if the nearest any's normal component is different
      * than the nearest normal version, use it. Or, if nothing else, use PATCH scope.
      */
-    static final SemVerStrategy DEFAULT = new SemVerStrategy(
+    static final wooga.gradle.version.internal.release.semver.SemVerStrategy DEFAULT = new wooga.gradle.version.internal.release.semver.SemVerStrategy(
         name: '',
         stages: [] as SortedSet,
         allowDirtyRepo: false,
-        normalStrategy: one(Normal.USE_SCOPE_PROP, Normal.USE_NEAREST_ANY, Normal.useScope(ChangeScope.PATCH)),
+        normalStrategy: one(Normal.USE_SCOPE_PROP, Normal.USE_NEAREST_ANY, Normal.useScope(wooga.gradle.version.internal.release.semver.ChangeScope.PATCH)),
         preReleaseStrategy: PreRelease.NONE,
         buildMetadataStrategy: BuildMetadata.NONE,
         createTag: true,
@@ -296,7 +296,7 @@ final class Strategies {
      * not enforce precedence. The pre-release compoment will always be "SNAPSHOT"
      * and no build metadata will be used. Tags will not be created for these versions.
      */
-    static final SemVerStrategy SNAPSHOT = DEFAULT.copyWith(
+    static final wooga.gradle.version.internal.release.semver.SemVerStrategy SNAPSHOT = DEFAULT.copyWith(
         name: 'snapshot',
         stages: ['SNAPSHOT'] as SortedSet,
         allowDirtyRepo: true,
@@ -314,7 +314,7 @@ final class Strategies {
      * will note if the repository is dirty. The abbreviated ID of the HEAD will
      * be used as build metadata.
      */
-    static final SemVerStrategy DEVELOPMENT = DEFAULT.copyWith(
+    static final wooga.gradle.version.internal.release.semver.SemVerStrategy DEVELOPMENT = DEFAULT.copyWith(
         name: 'development',
         stages: ['dev'] as SortedSet,
         allowDirtyRepo: true,
@@ -331,7 +331,7 @@ final class Strategies {
      * note that this strategy uses the same name as {@code PRE_RELEASE_ALPHA_BETA}
      * so it cannot be used at the same time.
      */
-    static final SemVerStrategy PRE_RELEASE = DEFAULT.copyWith(
+    static final wooga.gradle.version.internal.release.semver.SemVerStrategy PRE_RELEASE = DEFAULT.copyWith(
         name: 'pre-release',
         stages: ['milestone', 'rc'] as SortedSet,
         preReleaseStrategy: all(PreRelease.STAGE_FIXED, PreRelease.COUNT_INCREMENTED)
@@ -345,7 +345,7 @@ final class Strategies {
      * that this strategy uses the same name as {@code PRE_RELEASE} so it cannot be used
      * at the same time.
      */
-    static final SemVerStrategy PRE_RELEASE_ALPHA_BETA = PRE_RELEASE.copyWith(
+    static final wooga.gradle.version.internal.release.semver.SemVerStrategy PRE_RELEASE_ALPHA_BETA = PRE_RELEASE.copyWith(
         name: 'pre-release',
         stages: ['alpha', 'beta', 'rc'] as SortedSet
     )
@@ -355,7 +355,7 @@ final class Strategies {
      * will enforce precedence. The pre-release and build metadata components
      * will always be empty.
      */
-    static final SemVerStrategy FINAL = DEFAULT.copyWith(
+    static final wooga.gradle.version.internal.release.semver.SemVerStrategy FINAL = DEFAULT.copyWith(
         name: 'final',
         stages: ['final'] as SortedSet
     )

--- a/src/main/groovy/wooga/gradle/version/internal/release/opinion/package-info.groovy
+++ b/src/main/groovy/wooga/gradle/version/internal/release/opinion/package-info.groovy
@@ -16,4 +16,4 @@
 /**
  * Opinionated plugin and set of strategies build on top of the base package.
  */
-package org.ajoberstar.gradle.git.release.opinion
+package wooga.gradle.version.internal.release.opinion

--- a/src/main/groovy/wooga/gradle/version/internal/release/semver/ChangeScope.groovy
+++ b/src/main/groovy/wooga/gradle/version/internal/release/semver/ChangeScope.groovy
@@ -13,7 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/**
- * Support for version strategies that support semantic versioning.
- */
-package org.ajoberstar.gradle.git.release.semver
+package wooga.gradle.version.internal.release.semver
+
+enum ChangeScope {
+    MAJOR,
+    MINOR,
+    PATCH
+}

--- a/src/main/groovy/wooga/gradle/version/internal/release/semver/NearestVersion.groovy
+++ b/src/main/groovy/wooga/gradle/version/internal/release/semver/NearestVersion.groovy
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.ajoberstar.gradle.git.release.semver
+package wooga.gradle.version.internal.release.semver
 
 import groovy.transform.Immutable
 

--- a/src/main/groovy/wooga/gradle/version/internal/release/semver/NearestVersionLocator.groovy
+++ b/src/main/groovy/wooga/gradle/version/internal/release/semver/NearestVersionLocator.groovy
@@ -13,12 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.ajoberstar.gradle.git.release.semver
+package wooga.gradle.version.internal.release.semver
 
 import com.github.zafarkhaja.semver.Version
-import org.ajoberstar.gradle.git.release.base.TagStrategy
+import wooga.gradle.version.internal.release.base.TagStrategy
 import org.ajoberstar.grgit.Grgit
-import org.ajoberstar.grgit.Tag
 import org.eclipse.jgit.lib.ObjectId
 import org.eclipse.jgit.revwalk.RevCommit
 import org.eclipse.jgit.revwalk.RevWalk

--- a/src/main/groovy/wooga/gradle/version/internal/release/semver/PartialSemVerStrategy.groovy
+++ b/src/main/groovy/wooga/gradle/version/internal/release/semver/PartialSemVerStrategy.groovy
@@ -13,10 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.ajoberstar.gradle.git.release.semver
+package wooga.gradle.version.internal.release.semver
 
-enum ChangeScope {
-    MAJOR,
-    MINOR,
-    PATCH
+/**
+ * Strategy to infer portions of a semantic version.
+ * @see SemVerStrategy
+ */
+interface PartialSemVerStrategy {
+    /**
+     * Infers a portion of a semantic version and returns the new state
+     * to be used as inference continues.
+     */
+    SemVerStrategyState infer(SemVerStrategyState state)
 }

--- a/src/main/groovy/wooga/gradle/version/internal/release/semver/SemVerStrategy.groovy
+++ b/src/main/groovy/wooga/gradle/version/internal/release/semver/SemVerStrategy.groovy
@@ -13,14 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.ajoberstar.gradle.git.release.semver
+package wooga.gradle.version.internal.release.semver
 
 import groovy.transform.Immutable
 import groovy.transform.PackageScope
 
 import com.github.zafarkhaja.semver.Version
-import org.ajoberstar.gradle.git.release.base.ReleaseVersion
-import org.ajoberstar.gradle.git.release.base.DefaultVersionStrategy
+import wooga.gradle.version.internal.release.base.ReleaseVersion
+import wooga.gradle.version.internal.release.base.DefaultVersionStrategy
 import org.ajoberstar.grgit.Grgit
 
 import org.gradle.api.GradleException

--- a/src/main/groovy/wooga/gradle/version/internal/release/semver/SemVerStrategyState.groovy
+++ b/src/main/groovy/wooga/gradle/version/internal/release/semver/SemVerStrategyState.groovy
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.ajoberstar.gradle.git.release.semver
+package wooga.gradle.version.internal.release.semver
 
 import groovy.transform.Immutable
 import groovy.transform.ToString

--- a/src/main/groovy/wooga/gradle/version/internal/release/semver/StrategyUtil.groovy
+++ b/src/main/groovy/wooga/gradle/version/internal/release/semver/StrategyUtil.groovy
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.ajoberstar.gradle.git.release.semver
+package wooga.gradle.version.internal.release.semver
 
 /**
  * Utility class to more easily create {@link PartialSemVerStrategy} instances.

--- a/src/main/groovy/wooga/gradle/version/internal/release/semver/package-info.groovy
+++ b/src/main/groovy/wooga/gradle/version/internal/release/semver/package-info.groovy
@@ -13,16 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.ajoberstar.gradle.git.release.semver
-
 /**
- * Strategy to infer portions of a semantic version.
- * @see SemVerStrategy
+ * Support for version strategies that support semantic versioning.
  */
-interface PartialSemVerStrategy {
-    /**
-     * Infers a portion of a semantic version and returns the new state
-     * to be used as inference continues.
-     */
-    SemVerStrategyState infer(SemVerStrategyState state)
-}
+package wooga.gradle.version.internal.release.semver

--- a/src/main/groovy/wooga/gradle/version/strategies/NetflixOssStrategies.groovy
+++ b/src/main/groovy/wooga/gradle/version/strategies/NetflixOssStrategies.groovy
@@ -13,21 +13,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package nebula.plugin.release
+package wooga.gradle.version.strategies
 
-import org.ajoberstar.gradle.git.release.opinion.Strategies
-import org.ajoberstar.gradle.git.release.semver.ChangeScope
-import org.ajoberstar.gradle.git.release.semver.PartialSemVerStrategy
-import org.ajoberstar.gradle.git.release.semver.SemVerStrategy
-import org.ajoberstar.gradle.git.release.semver.StrategyUtil
+import wooga.gradle.version.internal.release.opinion.Strategies
+import wooga.gradle.version.internal.release.semver.ChangeScope
+import wooga.gradle.version.internal.release.semver.PartialSemVerStrategy
+import wooga.gradle.version.internal.release.semver.SemVerStrategy
+import wooga.gradle.version.internal.release.semver.StrategyUtil
 import org.gradle.api.GradleException
 import org.gradle.api.Project
 
 import java.util.regex.Pattern
 
-import static org.ajoberstar.gradle.git.release.semver.StrategyUtil.closure
-import static org.ajoberstar.gradle.git.release.semver.StrategyUtil.incrementNormalFromScope
-import static org.ajoberstar.gradle.git.release.semver.StrategyUtil.parseIntOrZero
+import static wooga.gradle.version.internal.release.semver.StrategyUtil.closure
+import static wooga.gradle.version.internal.release.semver.StrategyUtil.incrementNormalFromScope
+import static wooga.gradle.version.internal.release.semver.StrategyUtil.parseIntOrZero
 
 class NetflixOssStrategies {
     static final PartialSemVerStrategy TRAVIS_BRANCH_MAJOR_X = fromTravisPropertyPattern(~/^(\d+)\.x$/)

--- a/src/main/groovy/wooga/gradle/version/strategies/SemverV1Strategies.groovy
+++ b/src/main/groovy/wooga/gradle/version/strategies/SemverV1Strategies.groovy
@@ -17,16 +17,16 @@
 
 package wooga.gradle.version.strategies
 
-import nebula.plugin.release.NetflixOssStrategies
-import org.ajoberstar.gradle.git.release.opinion.Strategies
-import org.ajoberstar.gradle.git.release.semver.ChangeScope
-import org.ajoberstar.gradle.git.release.semver.PartialSemVerStrategy
-import org.ajoberstar.gradle.git.release.semver.SemVerStrategy
-import org.ajoberstar.gradle.git.release.semver.SemVerStrategyState
-import org.ajoberstar.gradle.git.release.semver.StrategyUtil
 
-import static org.ajoberstar.gradle.git.release.semver.StrategyUtil.closure
-import static org.ajoberstar.gradle.git.release.semver.StrategyUtil.parseIntOrZero
+import wooga.gradle.version.internal.release.opinion.Strategies
+import wooga.gradle.version.internal.release.semver.ChangeScope
+import wooga.gradle.version.internal.release.semver.PartialSemVerStrategy
+import wooga.gradle.version.internal.release.semver.SemVerStrategy
+import wooga.gradle.version.internal.release.semver.SemVerStrategyState
+import wooga.gradle.version.internal.release.semver.StrategyUtil
+
+import static wooga.gradle.version.internal.release.semver.StrategyUtil.closure
+import static wooga.gradle.version.internal.release.semver.StrategyUtil.parseIntOrZero
 
 class SemverV1Strategies {
     private static final scopes = StrategyUtil.one(

--- a/src/main/groovy/wooga/gradle/version/strategies/SemverV2Strategies.groovy
+++ b/src/main/groovy/wooga/gradle/version/strategies/SemverV2Strategies.groovy
@@ -17,17 +17,17 @@
 
 package wooga.gradle.version.strategies
 
-import nebula.plugin.release.NetflixOssStrategies
-import org.ajoberstar.gradle.git.release.opinion.Strategies
-import org.ajoberstar.gradle.git.release.opinion.Strategies.BuildMetadata
-import org.ajoberstar.gradle.git.release.semver.ChangeScope
-import org.ajoberstar.gradle.git.release.semver.PartialSemVerStrategy
-import org.ajoberstar.gradle.git.release.semver.SemVerStrategy
-import org.ajoberstar.gradle.git.release.semver.SemVerStrategyState
+
+import wooga.gradle.version.internal.release.opinion.Strategies
+import wooga.gradle.version.internal.release.opinion.Strategies.BuildMetadata
+import wooga.gradle.version.internal.release.semver.ChangeScope
+import wooga.gradle.version.internal.release.semver.PartialSemVerStrategy
+import wooga.gradle.version.internal.release.semver.SemVerStrategy
+import wooga.gradle.version.internal.release.semver.SemVerStrategyState
 
 import java.util.regex.Pattern
 
-import static org.ajoberstar.gradle.git.release.semver.StrategyUtil.*
+import static wooga.gradle.version.internal.release.semver.StrategyUtil.*
 
 final class SemverV2Strategies {
 


### PR DESCRIPTION
## Description

The forked sources of both nebular release and gradle-git create no problems in this project setup. When running the plugin it can happen that the original sources are called which are not API complained. I moved all forked sources into a new package.

## Changes

* ![IMPROVE] change package name of forked sources

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
