### PR TITLE
Refactor version provider

### DIFF
--- a/src/integrationTest/groovy/wooga/gradle/version/IntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/version/IntegrationSpec.groovy
@@ -64,6 +64,13 @@ class IntegrationSpec extends nebula.test.IntegrationSpec {
         def subType = (subtypeMatches.matches()) ? subtypeMatches.group("subType") : null
         type = (subtypeMatches.matches()) ? subtypeMatches.group("mainType") : type
         switch (type) {
+            case "VersionScheme":
+                if(VersionScheme.isInstance(rawValue)) {
+                    value = "wooga.gradle.version.VersionScheme.${rawValue.toString()}"
+                } else {
+                    value = "wooga.gradle.version.VersionScheme.valueOf('${rawValue.toString()}')"
+                }
+                break
             case "Closure":
                 if (subType) {
                     value = "{${wrapValueBasedOnType(rawValue, subType)}}"

--- a/src/integrationTest/groovy/wooga/gradle/version/VersionPluginIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/version/VersionPluginIntegrationSpec.groovy
@@ -92,29 +92,33 @@ class VersionPluginIntegrationSpec extends IntegrationSpec {
         result.standardOutput.contains("${extensionName}.${property}: ${testValue}")
 
         where:
-        property | value      | expectedValue     | location
-        "scope"  | "major"    | ChangeScope.MAJOR | PropertyLocation.env
-        "scope"  | "MAJOR"    | ChangeScope.MAJOR | PropertyLocation.env
-        "scope"  | "Major"    | ChangeScope.MAJOR | PropertyLocation.env
-        "scope"  | "minor"    | ChangeScope.MINOR | PropertyLocation.env
-        "scope"  | "MINOR"    | ChangeScope.MINOR | PropertyLocation.env
-        "scope"  | "Minor"    | ChangeScope.MINOR | PropertyLocation.env
-        "scope"  | "patch"    | ChangeScope.PATCH | PropertyLocation.env
-        "scope"  | "PATCH"    | ChangeScope.PATCH | PropertyLocation.env
-        "scope"  | "Patch"    | ChangeScope.PATCH | PropertyLocation.env
-        "scope"  | "major"    | ChangeScope.MAJOR | PropertyLocation.property
-        "scope"  | "MAJOR"    | ChangeScope.MAJOR | PropertyLocation.property
-        "scope"  | "Major"    | ChangeScope.MAJOR | PropertyLocation.property
-        "scope"  | "minor"    | ChangeScope.MINOR | PropertyLocation.property
-        "scope"  | "MINOR"    | ChangeScope.MINOR | PropertyLocation.property
-        "scope"  | "Minor"    | ChangeScope.MINOR | PropertyLocation.property
-        "scope"  | "patch"    | ChangeScope.PATCH | PropertyLocation.property
-        "scope"  | "PATCH"    | ChangeScope.PATCH | PropertyLocation.property
-        "scope"  | "Patch"    | ChangeScope.PATCH | PropertyLocation.property
-        "scope"  | "null"     | _                 | PropertyLocation.none
-        "stage"  | "snapshot" | _                 | PropertyLocation.env
-        "stage"  | "final"    | _                 | PropertyLocation.property
-        "stage"  | "null"     | _                 | PropertyLocation.none
+        property            | value               | expectedValue                       | location
+        "scope"             | "major"             | ChangeScope.MAJOR                   | PropertyLocation.env
+        "scope"             | "MAJOR"             | ChangeScope.MAJOR                   | PropertyLocation.env
+        "scope"             | "Major"             | ChangeScope.MAJOR                   | PropertyLocation.env
+        "scope"             | "minor"             | ChangeScope.MINOR                   | PropertyLocation.env
+        "scope"             | "MINOR"             | ChangeScope.MINOR                   | PropertyLocation.env
+        "scope"             | "Minor"             | ChangeScope.MINOR                   | PropertyLocation.env
+        "scope"             | "patch"             | ChangeScope.PATCH                   | PropertyLocation.env
+        "scope"             | "PATCH"             | ChangeScope.PATCH                   | PropertyLocation.env
+        "scope"             | "Patch"             | ChangeScope.PATCH                   | PropertyLocation.env
+        "scope"             | "major"             | ChangeScope.MAJOR                   | PropertyLocation.property
+        "scope"             | "MAJOR"             | ChangeScope.MAJOR                   | PropertyLocation.property
+        "scope"             | "Major"             | ChangeScope.MAJOR                   | PropertyLocation.property
+        "scope"             | "minor"             | ChangeScope.MINOR                   | PropertyLocation.property
+        "scope"             | "MINOR"             | ChangeScope.MINOR                   | PropertyLocation.property
+        "scope"             | "Minor"             | ChangeScope.MINOR                   | PropertyLocation.property
+        "scope"             | "patch"             | ChangeScope.PATCH                   | PropertyLocation.property
+        "scope"             | "PATCH"             | ChangeScope.PATCH                   | PropertyLocation.property
+        "scope"             | "Patch"             | ChangeScope.PATCH                   | PropertyLocation.property
+        "scope"             | "null"              | _                                   | PropertyLocation.none
+        "stage"             | "snapshot"          | _                                   | PropertyLocation.env
+        "stage"             | "final"             | _                                   | PropertyLocation.property
+        "stage"             | "null"              | _                                   | PropertyLocation.none
+        "versionScheme"     | "semver2"           | VersionScheme.semver2               | PropertyLocation.env
+        "versionScheme"     | "semver"            | VersionScheme.semver                | PropertyLocation.env
+        "versionScheme"     | "semver2"           | VersionScheme.semver2               | PropertyLocation.property
+        "versionScheme"     | "semver"            | VersionScheme.semver                | PropertyLocation.property
 
         extensionName = "versionBuilder"
         testValue = (expectedValue == _) ? value : expectedValue
@@ -148,12 +152,15 @@ class VersionPluginIntegrationSpec extends IntegrationSpec {
         result.standardOutput.contains("${extensionName}.${property}: ${rawValue}")
 
         where:
-        property | method       | rawValue | type
-        "scheme" | "scheme"     | "value1" | "String"
-        "scheme" | "scheme.set" | "value2" | "String"
-        "scheme" | "scheme.set" | "value2" | "Provider<String>"
-        "scheme" | "setScheme"  | "value2" | "String"
-        "scheme" | "setScheme"  | "value2" | "Provider<String>"
+        property            | method                  | rawValue                            | type
+        "versionScheme"     | "versionScheme"         | "semver"                            | "String"
+        "versionScheme"     | "versionScheme"         | VersionScheme.semver2               | "VersionScheme"
+        "versionScheme"     | "versionScheme"         | VersionScheme.semver                | "Provider<VersionScheme>"
+        "versionScheme"     | "versionScheme.set"     | VersionScheme.semver2               | "VersionScheme"
+        "versionScheme"     | "versionScheme.set"     | VersionScheme.semver                | "Provider<VersionScheme>"
+        "versionScheme"     | "setVersionScheme"      | "semver"                            | "String"
+        "versionScheme"     | "setVersionScheme"      | VersionScheme.semver2               | "VersionScheme"
+        "versionScheme"     | "setVersionScheme"      | VersionScheme.semver                | "Provider<VersionScheme>"
 
         value = wrapValueBasedOnType(rawValue, type)
         extensionName = "versionBuilder"

--- a/src/main/groovy/wooga/gradle/version/VersionConsts.groovy
+++ b/src/main/groovy/wooga/gradle/version/VersionConsts.groovy
@@ -22,16 +22,14 @@ class VersionConsts {
     static final String GIT_ROOT_PROPERTY = "git.root"
     static final String UNINITIALIZED_VERSION = '0.1.0-dev.0.uninitialized'
 
-    static final String VERSION_SCHEME_DEFAULT = VERSION_SCHEME_SEMVER_1
-    static final String VERSION_SCHEME_SEMVER_1 = 'semver'
-    static final String VERSION_SCHEME_SEMVER_2 = 'semver2'
+    static final VersionScheme VERSION_SCHEME_DEFAULT = VersionScheme.semver
 
     static final String LEGACY_VERSION_SCHEME_OPTION = "version.scheme"
     static final String LEGACY_VERSION_SCOPE_OPTION = "release.scope"
     static final String LEGACY_VERSION_STAGE_OPTION = "release.stage"
 
-    static final String VERSION_SCHEME_OPTION = "versionBuilder.scheme"
-    static final String VERSION_SCHEME_ENV_VAR = "VERSION_BUILDER_SCHEME"
+    static final String VERSION_SCHEME_OPTION = "versionBuilder.versionScheme"
+    static final String VERSION_SCHEME_ENV_VAR = "VERSION_BUILDER_VERSION_SCHEME"
 
     static final String VERSION_SCOPE_OPTION = "versionBuilder.scope"
     static final String VERSION_SCOPE_ENV_VAR = "VERSION_BUILDER_SCOPE"

--- a/src/main/groovy/wooga/gradle/version/VersionPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/version/VersionPluginExtension.groovy
@@ -27,10 +27,13 @@ import org.gradle.api.provider.Provider
 
 interface VersionPluginExtension {
 
-    Property<String> getScheme()
-    void scheme(String scheme)
-    void setScheme(String scheme)
-    void setScheme(Provider<String> scheme)
+    Property<VersionScheme> getVersionScheme()
+    void versionScheme(VersionScheme value)
+    void versionScheme(Provider<VersionScheme> value)
+    void versionScheme(String value)
+    void setVersionScheme(VersionScheme value)
+    void setVersionScheme(Provider<VersionScheme> value)
+    void setVersionScheme(String value)
 
     Property<Grgit> getGit()
 

--- a/src/main/groovy/wooga/gradle/version/VersionScheme.groovy
+++ b/src/main/groovy/wooga/gradle/version/VersionScheme.groovy
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2018-2020 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package wooga.gradle.version
+
+enum VersionScheme {
+    semver, semver2
+}
+
+

--- a/src/main/groovy/wooga/gradle/version/internal/MemoisationProvider.groovy
+++ b/src/main/groovy/wooga/gradle/version/internal/MemoisationProvider.groovy
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2018-2020 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package wooga.gradle.version.internal
+
+import org.gradle.api.internal.provider.AbstractProvider
+import org.gradle.api.provider.Provider
+
+class MemoisationProvider<T> extends AbstractProvider<T> implements Provider<T> {
+
+    private T inferredValue
+    private final Provider<T> inner
+
+    MemoisationProvider(Provider<T> provider) {
+        this.inner = provider
+    }
+
+    @Override
+    Class<T> getType() {
+        null
+    }
+
+    @Override
+    T getOrNull() {
+        if(!inferredValue) {
+            inferredValue = inner.getOrNull()
+        }
+        inferredValue
+    }
+}

--- a/src/main/groovy/wooga/gradle/version/internal/ToStringProvider.groovy
+++ b/src/main/groovy/wooga/gradle/version/internal/ToStringProvider.groovy
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2018-2020 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package wooga.gradle.version.internal
+
+import org.gradle.api.internal.provider.AbstractProvider
+import org.gradle.api.provider.Provider
+
+class ToStringProvider <T> extends AbstractProvider<T> implements Provider<T> {
+
+    private final Provider<T> inner
+
+    ToStringProvider(Provider<T> inner) {
+        this.inner = inner
+    }
+
+    @Override
+    Class<T> getType() {
+        return null
+    }
+
+    @Override
+    T getOrNull() {
+        return inner.getOrNull()
+    }
+
+    @Override
+    String toString() {
+        return getOrNull().toString()
+    }
+}

--- a/src/test/groovy/wooga/gradle/version/VersionPluginSpec.groovy
+++ b/src/test/groovy/wooga/gradle/version/VersionPluginSpec.groovy
@@ -22,6 +22,7 @@ import org.ajoberstar.grgit.Grgit
 import org.gradle.cache.internal.VersionStrategy
 import spock.lang.Ignore
 import spock.lang.Unroll
+import wooga.gradle.version.internal.ToStringProvider
 
 class VersionPluginSpec extends ProjectSpec {
 
@@ -478,6 +479,20 @@ class VersionPluginSpec extends ProjectSpec {
         nearestNormal = '1.0.0'
         nearestAnyTitle = (nearestAny == _) ? "unset" : nearestAny
         scopeTitle = (scope == _) ? "unset" : scope
+    }
+
+    @Unroll
+    def "project property #property is a #type"() {
+        given:
+        project.plugins.apply(PLUGIN_NAME)
+        def value = project.property(property)
+
+        expect:
+        type.isInstance(value)
+
+        where:
+        property      | type
+        "version"     | ToStringProvider.class
     }
 
     @Unroll('verify version branch rename for branch #branchName')

--- a/src/test/groovy/wooga/gradle/version/internal/MemoisationProviderSpec.groovy
+++ b/src/test/groovy/wooga/gradle/version/internal/MemoisationProviderSpec.groovy
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2018-2020 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package wooga.gradle.version.internal
+
+import nebula.test.ProjectSpec
+import spock.lang.Unroll
+
+class MemoisationProviderSpec extends ProjectSpec {
+    def "provider caches value"() {
+        given: "a random number generator"
+        def random = new Random()
+        and: "a normal provider"
+        def baseProvider = project.provider({ random.nextInt() })
+
+        and: "a memoisation provider"
+        def subject = new MemoisationProvider(baseProvider)
+
+        expect:
+        subject.get() == subject.get()
+        subject.get() == subject.get()
+        subject.get() == subject.get()
+        baseProvider.get() != baseProvider.get()
+        baseProvider.get() != baseProvider.get()
+        baseProvider.get() != baseProvider.get()
+    }
+
+    @Unroll
+    def "getOrNull returns value or null"() {
+        given: "a memoisation provider"
+        def baseProvider = project.provider({ innerValue })
+        def subject = new MemoisationProvider(baseProvider)
+
+        when:
+        def value = subject.getOrNull()
+
+        then:
+        value == innerValue
+        noExceptionThrown()
+
+        where:
+        innerValue << [1, null]
+    }
+
+    @Unroll
+    def "get throws error when value is null"() {
+        given: "a memoisation provider"
+        def baseProvider = project.provider({ null })
+        def subject = new MemoisationProvider(baseProvider)
+
+        when:
+        subject.get()
+
+        then:
+        thrown(IllegalStateException)
+    }
+
+    @Unroll
+    def "present returns #expectedValue when value is #message"() {
+        given: "a memoisation provider"
+        def baseProvider = project.provider({ innerValue })
+        def subject = new MemoisationProvider(baseProvider)
+
+        when:
+        def value = subject.isPresent()
+
+        then:
+        value == expectedValue
+
+        where:
+        innerValue | expectedValue
+        1          | true
+        null       | false
+        message = innerValue == null ? "not set" : "set"
+    }
+}

--- a/src/test/groovy/wooga/gradle/version/internal/ToStringProviderSpec.groovy
+++ b/src/test/groovy/wooga/gradle/version/internal/ToStringProviderSpec.groovy
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2018-2020 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package wooga.gradle.version.internal
+
+import nebula.test.ProjectSpec
+import spock.lang.Unroll
+
+class ToStringProviderSpec extends ProjectSpec {
+
+    @Unroll
+    def "toString calls toString on enclosed value"() {
+        given: "a provider"
+        def baseProvider = project.provider({ innerValue })
+        def subject = new ToStringProvider(baseProvider)
+
+        when:
+        def value = subject.toString()
+
+        then:
+        value == expectedToString
+        value != baseProvider.toString()
+
+        where:
+        innerValue | expectedToString
+        1          | "1"
+        null       | "null"
+        "test"     | "test"
+    }
+
+    @Unroll
+    def "getOrNull returns value or null"() {
+        given: "a provider"
+        def baseProvider = project.provider({ innerValue })
+        def subject = new ToStringProvider(baseProvider)
+
+        when:
+        def value = subject.getOrNull()
+
+        then:
+        value == innerValue
+        noExceptionThrown()
+
+        where:
+        innerValue << [1, null]
+    }
+
+    @Unroll
+    def "get throws error when value is null"() {
+        given: "a provider"
+        def baseProvider = project.provider({ null })
+        def subject = new ToStringProvider(baseProvider)
+
+        when:
+        subject.get()
+
+        then:
+        thrown(IllegalStateException)
+    }
+
+    @Unroll
+    def "present returns #expectedValue when value is #message"() {
+        given: "a provider"
+        def baseProvider = project.provider({ innerValue })
+        def subject = new ToStringProvider(baseProvider)
+
+        when:
+        def value = subject.isPresent()
+
+        then:
+        value == expectedValue
+
+        where:
+        innerValue | expectedValue
+        1          | true
+        null       | false
+        message = innerValue == null ? "not set" : "set"
+    }
+}


### PR DESCRIPTION
## Description

This is a small cleanup patch to prepare the next `versionCode` implementation. I renamed the extension property `scheme` to `versionScheme` and also adjusted the type to an enum `VersionScheme`. I left the ability to set this value from `String` to make it easier to set the value in the `build.gradle` script.

I wrapped the version provider in a new custom provider which can cache the infered value. This whole provider gets wrapped again in a special `ToStringProvider`. This providers `toString` method will evaluate the internal value and call `toString` on it. The default `Provider` instances only provide a basic `toString` implementation.

I also added more test cases for the new APIs and classes

## Changes

* ![CHANGE] `scheme` to `versionScheme`
* ![CHANGE] `versionScheme` type from `String` to `VersionScheme`
* ![ADD] `MemoisationProvider`
* ![ADD] `ToStringProvider`
* ![IMPROVE] `versionScheme` API overloads* ![IMPROVE] `versionScheme`
  API overloads

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:https://atlas-resources.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:https://atlas-resources.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:https://atlas-resources.wooga.com/icons/icon_change.svg "Change"
[FIX]:https://atlas-resources.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:https://atlas-resources.wooga.com/icons/icon_update.svg "Update"

[BREAK]:https://atlas-resources.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:https://atlas-resources.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:https://atlas-resources.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:https://atlas-resources.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:https://atlas-resources.wooga.com/icons/icon_webGL.svg "Web:GL"
[GRADLE]:https://atlas-resources.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:https://atlas-resources.wooga.com/icons/icon_unity.svg "Unity"
