### PR TITLE
Add versionCode generation

### DIFF
--- a/src/integrationTest/groovy/wooga/gradle/version/IntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/version/IntegrationSpec.groovy
@@ -71,6 +71,13 @@ class IntegrationSpec extends nebula.test.IntegrationSpec {
                     value = "wooga.gradle.version.VersionScheme.valueOf('${rawValue.toString()}')"
                 }
                 break
+            case "VersionCodeScheme":
+                if(VersionCodeScheme.isInstance(rawValue)) {
+                    value = "wooga.gradle.version.VersionCodeScheme.${rawValue.toString()}"
+                } else {
+                    value = "wooga.gradle.version.VersionCodeScheme.valueOf('${rawValue.toString()}')"
+                }
+                break
             case "Closure":
                 if (subType) {
                     value = "{${wrapValueBasedOnType(rawValue, subType)}}"

--- a/src/main/groovy/wooga/gradle/version/VersionCodeExtension.groovy
+++ b/src/main/groovy/wooga/gradle/version/VersionCodeExtension.groovy
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2018-2020 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package wooga.gradle.version
+
+import org.gradle.api.provider.Property
+
+interface VersionCodeExtension extends Property<Integer> {
+    String toString()
+}

--- a/src/main/groovy/wooga/gradle/version/VersionCodeScheme.groovy
+++ b/src/main/groovy/wooga/gradle/version/VersionCodeScheme.groovy
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2018-2020 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package wooga.gradle.version
+
+enum VersionCodeScheme {
+    none, semver, semverBasic, releaseCountBasic, releaseCount
+}

--- a/src/main/groovy/wooga/gradle/version/VersionConsts.groovy
+++ b/src/main/groovy/wooga/gradle/version/VersionConsts.groovy
@@ -23,6 +23,7 @@ class VersionConsts {
     static final String UNINITIALIZED_VERSION = '0.1.0-dev.0.uninitialized'
 
     static final VersionScheme VERSION_SCHEME_DEFAULT = VersionScheme.semver
+    static final VersionCodeScheme VERSION_CODE_SCHEME_DEFAULT = VersionCodeScheme.none
 
     static final String LEGACY_VERSION_SCHEME_OPTION = "version.scheme"
     static final String LEGACY_VERSION_SCOPE_OPTION = "release.scope"
@@ -30,6 +31,12 @@ class VersionConsts {
 
     static final String VERSION_SCHEME_OPTION = "versionBuilder.versionScheme"
     static final String VERSION_SCHEME_ENV_VAR = "VERSION_BUILDER_VERSION_SCHEME"
+
+    static final String VERSION_CODE_SCHEME_OPTION = "versionBuilder.versionCodeScheme"
+    static final String VERSION_CODE_SCHEME_ENV_VAR = "VERSION_BUILDER_VERSION_CODE_SCHEME"
+
+    static final String VERSION_CODE_OFFSET_OPTION = "versionBuilder.versionCodeOffset"
+    static final String VERSION_CODE_OFFSET_ENV_VAR = "VERSION_BUILDER_VERSION_CODE_OFFSET"
 
     static final String VERSION_SCOPE_OPTION = "versionBuilder.scope"
     static final String VERSION_SCOPE_ENV_VAR = "VERSION_BUILDER_SCOPE"

--- a/src/main/groovy/wooga/gradle/version/VersionPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/version/VersionPlugin.groovy
@@ -24,6 +24,7 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.logging.Logging
 import org.slf4j.Logger
+import wooga.gradle.version.internal.DefaultVersionCodeExtension
 import wooga.gradle.version.internal.DefaultVersionPluginExtension
 import wooga.gradle.version.internal.ToStringProvider
 
@@ -57,6 +58,7 @@ class VersionPlugin implements Plugin<Project> {
                 @Override
                 void execute(Project prj) {
                     prj.setVersion(sharedVersion)
+                    prj.extensions.create(VersionCodeExtension, "versionCode", DefaultVersionCodeExtension.class, prj, extension.versionCode)
                 }
             })
         }
@@ -73,6 +75,21 @@ class VersionPlugin implements Plugin<Project> {
                 return VersionScheme.valueOf(rawValue.toString().trim())
             }
             VersionConsts.VERSION_SCHEME_DEFAULT
+        }))
+
+        extension.versionCodeScheme.set(project.provider({
+            def rawValue = System.getenv()[VersionConsts.VERSION_CODE_SCHEME_ENV_VAR] ?:
+                    project.properties.get(VersionConsts.VERSION_CODE_SCHEME_OPTION)
+            if(rawValue) {
+                return VersionCodeScheme.valueOf(rawValue.toString().trim())
+            }
+            VersionConsts.VERSION_CODE_SCHEME_DEFAULT
+        }))
+
+        extension.versionCodeOffset.set(project.provider({
+            def rawValue = System.getenv()[VersionConsts.VERSION_CODE_OFFSET_ENV_VAR] ?:
+                    project.properties.getOrDefault(VersionConsts.VERSION_CODE_OFFSET_OPTION, "0")
+            Integer.parseInt(rawValue.toString())
         }))
 
         extension

--- a/src/main/groovy/wooga/gradle/version/VersionPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/version/VersionPluginExtension.groovy
@@ -35,9 +35,25 @@ interface VersionPluginExtension {
     void setVersionScheme(Provider<VersionScheme> value)
     void setVersionScheme(String value)
 
+    Property<VersionCodeScheme> getVersionCodeScheme()
+    void versionCodeScheme(VersionCodeScheme value)
+    void versionCodeScheme(Provider<VersionCodeScheme> value)
+    void versionCodeScheme(String value)
+    void setVersionCodeScheme(VersionCodeScheme value)
+    void setVersionCodeScheme(Provider<VersionCodeScheme> value)
+    void setVersionCodeScheme(String value)
+
+    Property<Integer> getVersionCodeOffset()
+    void versionCodeOffset(Integer value)
+    void versionCodeOffset(Provider<Integer> value)
+    void setVersionCodeOffset(Integer value)
+    void setVersionCodeOffset(Provider<Integer> value)
+
     Property<Grgit> getGit()
 
     Provider<ReleaseVersion> getVersion()
+    Provider<Integer> getVersionCode()
+
     Provider<String> getStage()
     Provider<ChangeScope> getScope()
 

--- a/src/main/groovy/wooga/gradle/version/internal/DefaultVersionCodeExtension.groovy
+++ b/src/main/groovy/wooga/gradle/version/internal/DefaultVersionCodeExtension.groovy
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2018-2020 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package wooga.gradle.version.internal
+
+import org.gradle.api.Project
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.Provider
+import wooga.gradle.version.VersionCodeExtension
+
+class DefaultVersionCodeExtension implements VersionCodeExtension {
+    @Delegate
+    private final Property<Integer> innerProvider
+
+    DefaultVersionCodeExtension(Project project, Provider < Integer > innerProvider) {
+        this.innerProvider = project.objects.property(Integer)
+        this.innerProvider.set(innerProvider)
+    }
+
+    @Override
+    String toString() {
+        return innerProvider.getOrNull().toString()
+    }
+}

--- a/src/main/groovy/wooga/gradle/version/internal/VersionCode.groovy
+++ b/src/main/groovy/wooga/gradle/version/internal/VersionCode.groovy
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2018-2020 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package wooga.gradle.version.internal
+
+import com.sun.org.apache.xpath.internal.operations.Bool
+import org.ajoberstar.grgit.Grgit
+import org.eclipse.jgit.lib.ObjectId
+import org.eclipse.jgit.revwalk.RevCommit
+import org.eclipse.jgit.revwalk.RevWalk
+import wooga.gradle.version.internal.release.base.TagStrategy
+
+class VersionCode {
+    /**
+     * Returns a version code base on the given semver version.
+     *
+     * The returned versioncode is in the form of
+     * <pre>
+     * {@code
+     *   major | minor | patch | revision
+     *    00      00      00       0
+     *}
+     * </pre>
+     * The method will only pull the {@code major}, @{code minor} and {@code patch} components out of the version.
+     * Not all valid semver versions can be converted. The maximum value for {@code major}, @{code minor} and
+     * {@code patch} components is @{code 99}. The greates valid version is @{code 99.99.99}.
+     * The revision field will only be populated when passing a special {@code staging} version e.g. {@code 1.0.0-staging.1}.
+     * The length of the revision value is only a single digit so a maximum of 8 staging versions can be represented.
+     * <p>
+     * Example:
+     * <pre>
+     * "1.0.0"             => 100000
+     * "1.2.3"             => 102030
+     * "1.2.3-staging.1"   => 102031
+     * "0.22.0-develop.93" => 22000
+     * </pre>
+     *
+     * @param version A semver 2.0 compatible version string
+     * @return a versioncode for the provided version
+     *
+     */
+    static Integer generateSemverVersionCode(String version, Boolean includeRevision = false) {
+        def versionMatch = version =~ /(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)(-staging\.(?<rev>\d+))?.*?/
+
+        if (!versionMatch.matches()) {
+            throw new IllegalArgumentException("Failed to generate versioncode. Invalid version (${version}). Please provide version in form of '0.0.0'")
+        }
+        def versionCode = 0
+        def versionMajor = versionMatch.group("major").toInteger()
+        def versionMinor = versionMatch.group('minor').toInteger()
+        def versionPatch = versionMatch.group('patch').toInteger()
+        def versionRev = (versionMatch.group('rev') ?: "0").toInteger()
+
+        def errors = []
+
+        if (versionMajor > 99) {
+            errors << "Major component > 99"
+        }
+
+        if (versionMinor > 99) {
+            errors << "Minor component > 99"
+        }
+
+        if (versionPatch > 99) {
+            errors << "Patch component > 99"
+        }
+
+        if (includeRevision && versionRev > 9) {
+            errors << "Staging Revision > 9"
+        }
+
+        if (!errors.empty) {
+            throw new IllegalArgumentException("Failed to generate versioncode. ${errors.join(". ")}(${version})")
+        }
+
+        versionCode += versionMajor * 10000
+        versionCode += versionMinor * 100
+        versionCode += versionPatch * 1
+
+        if(includeRevision) {
+            versionCode *= 10
+            versionCode += versionRev
+        }
+
+        versionCode
+    }
+
+    /**
+     * Returns a versioncode based on the number of version tags in the given git repository + 1
+     *
+     * @param git
+     * @param countPrerelease
+     * @param offset
+     * @return
+     */
+    static Integer generateBuildNumberVersionCode(Grgit git, Boolean countPrerelease = true, Integer offset = 0) {
+        RevWalk walk = new RevWalk(git.repository.jgit.repo)
+        def strategy = new TagStrategy(false)
+
+        try {
+            walk.retainBody = false
+
+            def toRev = { obj ->
+                def commit = git.resolve.toCommit(obj)
+                def id = ObjectId.fromString(commit.id)
+                walk.parseCommit(id)
+            }
+
+            List tags = git.tag.list().collect { tag ->
+                [version: strategy.parseTag(tag), tag: tag, rev: toRev(tag)]
+            }.findAll {
+                it.version
+            }
+
+            List normalTags = tags.findAll { !it.version.preReleaseVersion }
+            RevCommit head = toRev(git.head())
+
+            def tagsToCalculate = (countPrerelease) ? tags : normalTags
+            return countReachableVersionTags(walk, head, tagsToCalculate) + offset + 1
+        } finally {
+            walk.close()
+        }
+    }
+
+    private static Integer countReachableVersionTags(RevWalk walk, RevCommit head, List versionTags) {
+        walk.reset()
+        walk.markStart(head)
+        Map versionTagsByRev = versionTags.groupBy { it.rev }
+
+        def reachableVersionTags = walk.collectMany { versionTagsByRev.get(it,[]) }
+
+        if (reachableVersionTags) {
+            return reachableVersionTags.size()
+        } else {
+            return 0
+        }
+    }
+}

--- a/src/main/groovy/wooga/gradle/version/internal/release/base/TagStrategy.groovy
+++ b/src/main/groovy/wooga/gradle/version/internal/release/base/TagStrategy.groovy
@@ -26,7 +26,7 @@ import org.slf4j.LoggerFactory
  * Strategy for creating a Git tag associated with a release.
  */
 class TagStrategy {
-
+    final boolean parseVersionsWithoutPrefixV
     /**
      * Closure taking a version String as an argument and returning a string to be used as a tag name.
      */
@@ -38,14 +38,25 @@ class TagStrategy {
      */
     Closure<Version> parseTag = { Tag tag ->
         try {
-            Version.valueOf(tag.name[0] == 'v' ? tag.name[1..-1] : tag.name)
+            if(parseVersionsWithoutPrefixV) {
+                Version.valueOf(tag.name[0] == 'v' ? tag.name[1..-1] : tag.name)
+            } else
+            {
+                Version.valueOf(tag.name[1..-1])
+            }
+
         } catch (ParseException e) {
             null
         }
     }
 
-    TagStrategy() {
+    TagStrategy(boolean parseVersionsWithoutPrefixV) {
+        this.prefixNameWithV = parseVersionsWithoutPrefixV
         setPrefixNameWithV(true)
+    }
+
+    TagStrategy() {
+        this(true)
     }
 
     private static final Logger logger = LoggerFactory.getLogger(TagStrategy)

--- a/src/test/groovy/wooga/gradle/version/internal/VersionCodeSpec.groovy
+++ b/src/test/groovy/wooga/gradle/version/internal/VersionCodeSpec.groovy
@@ -1,0 +1,183 @@
+/*
+ * Copyright 2018-2020 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package wooga.gradle.version.internal
+
+import org.ajoberstar.grgit.Grgit
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class VersionCodeSpec extends Specification {
+
+    @Unroll
+    def ":generateSemverVersionCode generates unique versioncode #message #expectedVersionCode from version #version"() {
+        expect:
+        VersionCode.generateSemverVersionCode(version, includeRevision) == expectedVersionCode
+        where:
+        version              | expectedVersionCode | includeRevision
+        "1.0.0"              | 100000              | true
+        "1.2.3"              | 102030              | true
+        "10.20.30"           | 1020300             | true
+        "1.2.3-staging.1"    | 102031              | true
+        "3.4.1-rc.5"         | 304010              | true
+        "0.22.0-develop.93"  | 22000               | true
+        "1.22.0-develop.111" | 122000              | true
+        "3.2.2develop.111"   | 302020              | true
+        "99.99.99-staging.9" | 9999999             | true
+        "99.99.99-dev.9"     | 9999990             | true
+        "1.0.0"              | 10000               | false
+        "1.2.3"              | 10203               | false
+        "10.20.30"           | 102030              | false
+        "1.2.3-staging.1"    | 10203               | false
+        "3.4.1-rc.5"         | 30401               | false
+        "0.22.0-develop.93"  | 2200                | false
+        "1.22.0-develop.111" | 12200               | false
+        "3.2.2develop.111"   | 30202               | false
+        "99.99.99-staging.9" | 999999              | false
+        "99.99.99-dev.9"     | 999999              | false
+        message = (includeRevision) ? "with revision" : ""
+    }
+
+    @Unroll
+    def ":generateSemverVersionCode throws error for #version #message because #expectedError"() {
+        when:
+        VersionCode.generateSemverVersionCode(version, includeRevision)
+
+        then:
+        def e = thrown(IllegalArgumentException)
+        e.message.contains(expectedError)
+
+        where:
+        version                  | expectedError          | includeRevision
+        "100.2.3"                | "Major component > 99" | true
+        "1.100.3"                | "Minor component > 99" | true
+        "1.1.100"                | "Patch component > 99" | true
+        "1.2.3-staging.11"       | "Staging Revision > 9" | true
+        "100.100.100-staging.10" | "Major component > 99" | true
+        "100.100.100-staging.10" | "Minor component > 99" | true
+        "100.100.100-staging.10" | "Patch component > 99" | true
+        "100.100.100-staging.10" | "Staging Revision > 9" | true
+        "aaaa"                   | "Invalid version"      | true
+        "1.a.3"                  | "Invalid version"      | true
+        "100.2.3"                | "Major component > 99" | false
+        "1.100.3"                | "Minor component > 99" | false
+        "1.1.100"                | "Patch component > 99" | false
+        "100.100.100-staging.10" | "Major component > 99" | false
+        "100.100.100-staging.10" | "Minor component > 99" | false
+        "100.100.100-staging.10" | "Patch component > 99" | false
+        "aaaa"                   | "Invalid version"      | false
+        "1.a.3"                  | "Invalid version"      | false
+        message = (includeRevision) ? "with revision" : ""
+    }
+
+    @Unroll
+    def ":generateSemverVersionCode throws no error for #version when no revision counter is requested"() {
+        when:
+        VersionCode.generateSemverVersionCode(version, includeRevision)
+
+        then:
+        noExceptionThrown()
+
+        where:
+        version                  | includeRevision
+        "1.2.3-staging.11"       | false
+    }
+
+    @Unroll
+    def ":generateBuildNumberVersionCode returns number of releases #message"() {
+        given: "a repo with a specific number of releases"
+        def tempDir = File.createTempDir()
+        tempDir.deleteOnExit()
+
+        Grgit git = Grgit.init(dir: tempDir)
+        git.commit(message: 'initial commit')
+
+        numberOfNormalTags.times {
+            git.commit(message: 'a commit')
+            if (it < numberOfPrereleaseTags) {
+                git.tag.add(name: "${it}.0.0-rc.1")
+                git.tag.add(name: "v${it}.0.0-rc.1")
+            }
+            git.tag.add(name: "v${it}.0.0")
+        }
+
+        Math.max(numberOfPrereleaseTags - numberOfNormalTags, 0).times {
+            git.commit(message: 'a commit')
+            git.tag.add(name: "v${numberOfNormalTags + 1}.0.0-rc.${it}")
+        }
+
+        expect:
+        VersionCode.generateBuildNumberVersionCode(git, countPrerelease, offset) == expectedValue
+
+        cleanup:
+        tempDir.deleteDir()
+
+        where:
+        numberOfNormalTags | numberOfPrereleaseTags | offset | countPrerelease
+        1                  | 0                      | 0      | false
+        1                  | 1                      | 0      | false
+        1                  | 1                      | 40     | false
+        1                  | 1                      | 0      | true
+        3                  | 2                      | 100    | true
+        3                  | 5                      | 10     | true
+
+        message = "when number of normal tags: ${numberOfNormalTags} prerelease tags: ${numberOfPrereleaseTags} and offset: ${offset}"
+        expectedValue = numberOfNormalTags + offset + (countPrerelease ? numberOfPrereleaseTags : 0) + 1
+    }
+
+    @Unroll
+    def ":generateBuildNumberVersionCode only counts reachable release tags"() {
+        given: "a repo with a specific number of releases"
+        def tempDir = File.createTempDir()
+        tempDir.deleteOnExit()
+
+        Grgit git = Grgit.init(dir: tempDir)
+        git.commit(message: 'initial commit')
+        git.commit(message: 'a commit')
+        git.tag.add(name: "v1.0.0-rc.1")
+        git.commit(message: 'a commit')
+        git.tag.add(name: "v1.0.0-rc.2")
+        git.tag.add(name: "v1.0.0")
+        git.branch.add(name: 'develop', startPoint: 'master')
+        git.checkout(branch: "develop")
+        git.commit(message: 'a commit')
+        git.commit(message: 'a commit')
+        git.commit(message: 'a commit')
+        git.tag.add(name: "v1.0.1-rc.1")
+
+        and: "the correct branch"
+        git.checkout(branch: branch)
+
+        expect:
+        VersionCode.generateBuildNumberVersionCode(git, countPrerelease, offset) == expectedValue
+
+        cleanup:
+        tempDir.deleteDir()
+
+        where:
+        branch    | offset | countPrerelease | expectedValue
+        "master"  | 0      | false           | 2
+        "master"  | 0      | true            | 4
+        "master"  | 10     | true            | 14
+        "master"  | 20     | false           | 22
+        "develop" | 0      | false           | 2
+        "develop" | 0      | true            | 5
+        "develop" | 30     | false           | 32
+        "develop" | 40     | true            | 45
+    }
+}


### PR DESCRIPTION
## Description

This patch adds multiple schemes to generate or manual set a versionCode. The strategies differ in two major ways:

### semver version based

A strategy based on a `semver` version number. This patch provides two `schemes` to generate a version code from a given semver version string:

#### `semverBasic`

This scheme turns a semver version `major.minor.patch` into a integer representation. Everything after the components is ignored. The version components are not allowed to be higher than `99` This means that the biggest version provided possible is `99.99.99`. The resulting code is an integer with padded values.

`1.0.0`   => `10000`
`1.1.1`   => `10101`
`1.11.10` => `11110`

#### `semver`

The `semver` scheme is an opinionated addon to the `semverBasic` scheme. The resulting code is extended by a revision counter. This counter has only one digit so can't be higher than `9`. The revision is parsed from a version with `-staging.{revision}` appended.

`1.0.0`           => `100000`
`1.0.0-staging.3` => `100003

### release count based

These schemes act more as a build number generator by counting all reachable release tags from the current branch. An optional `offset` can be provided to keep the generated version-code over a certain limit.

#### `releaseCountBasic`

Counts all reachable tags in the repo with final release versions appended (e.g `v1.1.0`). It will skip any prerelease tags or any other tags.

_ `releaseCount`_

Counts all kinds of release tags reachable from the current branch. (e.g. `v1.1.0`, `v1.2.0-staging.1`)

### configuration

*build.gradle*

```groovy
plugins {
    id "net.wooga.version" version "VERSION"
}

versionBuilder {
   versionScheme = "semver2"
   versionCodeScheme = "releaseCount"
   versionCodeOffset = 1000
}
```

The plugin will set a `versionCode` extension to all projects. This value is of type `VersionCodeExtension` which implements the gradle `Provider` interface. To retrieve the value you need to call `get` or `getOrNull` or `getOrDefault` The version-code generation process is lazy like the version infer logic. If you pass this value to a task that also uses the provider API, you can use this value directly or call `map` to convert it to a fitting type.

### Manual versioncode

You can also manually set a versionCode. This has to be done after this plugin is applied.

```groovy
plugins {
    id "net.wooga.version" version "VERSION"
}

allprojects { prj ->
   //use the property created by the plugin
   prj.versionCode.set(12345)

   //replace the extension
   prj.ext.versionCode = 12345
}
```

In both cases, the effictive versioncode will be `12345` but be carefull when replacing the extension. You could change the type of the value. And the behavior changes. Use the provided `Property.set` method.

## Changes

* ![ADD] version-code generation

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:https://atlas-resources.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:https://atlas-resources.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:https://atlas-resources.wooga.com/icons/icon_change.svg "Change"
[FIX]:https://atlas-resources.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:https://atlas-resources.wooga.com/icons/icon_update.svg "Update"

[BREAK]:https://atlas-resources.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:https://atlas-resources.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:https://atlas-resources.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:https://atlas-resources.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:https://atlas-resources.wooga.com/icons/icon_webGL.svg "Web:GL"
[GRADLE]:https://atlas-resources.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:https://atlas-resources.wooga.com/icons/icon_unity.svg "Unity"
