### PR TITLE
Fix TagStrategy tag prefix parsing default value

### DIFF
--- a/src/main/groovy/wooga/gradle/version/internal/release/base/TagStrategy.groovy
+++ b/src/main/groovy/wooga/gradle/version/internal/release/base/TagStrategy.groovy
@@ -51,7 +51,7 @@ class TagStrategy {
     }
 
     TagStrategy(boolean parseVersionsWithoutPrefixV) {
-        this.prefixNameWithV = parseVersionsWithoutPrefixV
+        this.parseVersionsWithoutPrefixV = parseVersionsWithoutPrefixV
         setPrefixNameWithV(true)
     }
 


### PR DESCRIPTION
## Description

With the patch [#7] I added a regression. Because of a type I disabled parsing of tags without a prefix `v`. I had no tests in place for this behavior so this ended up in the latest `rc` build [v0.1.0-rc.4].

My intention was to set the new added field `parseVersionsWithoutPrefixV` to true for the default constructor. Instead I picked the groovy generated `field` for the `setPrefixNameWithV` (`prefixNameWithV`).

I fixed the issue and added a small set of regression tests.

## Changes

* ![FIX] `TagStrategy` tag prefix parsing default value

[#7]:  https://github.com/wooga/atlas-version/pull/7
[v0.1.0-rc.4]: https://github.com/wooga/atlas-version/releases/tag/v0.1.0-rc.4


[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:https://atlas-resources.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:https://atlas-resources.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:https://atlas-resources.wooga.com/icons/icon_change.svg "Change"
[FIX]:https://atlas-resources.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:https://atlas-resources.wooga.com/icons/icon_update.svg "Update"

[BREAK]:https://atlas-resources.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:https://atlas-resources.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:https://atlas-resources.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:https://atlas-resources.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:https://atlas-resources.wooga.com/icons/icon_webGL.svg "Web:GL"
[GRADLE]:https://atlas-resources.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:https://atlas-resources.wooga.com/icons/icon_unity.svg "Unity"
