### PR TITLE
Add new strategy staticMarker

### DIFF
--- a/src/integrationTest/groovy/wooga/gradle/version/VersionPluginIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/version/VersionPluginIntegrationSpec.groovy
@@ -92,43 +92,49 @@ class VersionPluginIntegrationSpec extends IntegrationSpec {
         result.standardOutput.contains("${extensionName}.${property}: ${testValue}")
 
         where:
-        property            | value               | expectedValue                       | location
-        "scope"             | "major"             | ChangeScope.MAJOR                   | PropertyLocation.env
-        "scope"             | "MAJOR"             | ChangeScope.MAJOR                   | PropertyLocation.env
-        "scope"             | "Major"             | ChangeScope.MAJOR                   | PropertyLocation.env
-        "scope"             | "minor"             | ChangeScope.MINOR                   | PropertyLocation.env
-        "scope"             | "MINOR"             | ChangeScope.MINOR                   | PropertyLocation.env
-        "scope"             | "Minor"             | ChangeScope.MINOR                   | PropertyLocation.env
-        "scope"             | "patch"             | ChangeScope.PATCH                   | PropertyLocation.env
-        "scope"             | "PATCH"             | ChangeScope.PATCH                   | PropertyLocation.env
-        "scope"             | "Patch"             | ChangeScope.PATCH                   | PropertyLocation.env
-        "scope"             | "major"             | ChangeScope.MAJOR                   | PropertyLocation.property
-        "scope"             | "MAJOR"             | ChangeScope.MAJOR                   | PropertyLocation.property
-        "scope"             | "Major"             | ChangeScope.MAJOR                   | PropertyLocation.property
-        "scope"             | "minor"             | ChangeScope.MINOR                   | PropertyLocation.property
-        "scope"             | "MINOR"             | ChangeScope.MINOR                   | PropertyLocation.property
-        "scope"             | "Minor"             | ChangeScope.MINOR                   | PropertyLocation.property
-        "scope"             | "patch"             | ChangeScope.PATCH                   | PropertyLocation.property
-        "scope"             | "PATCH"             | ChangeScope.PATCH                   | PropertyLocation.property
-        "scope"             | "Patch"             | ChangeScope.PATCH                   | PropertyLocation.property
-        "scope"             | "null"              | _                                   | PropertyLocation.none
-        "stage"             | "snapshot"          | _                                   | PropertyLocation.env
-        "stage"             | "final"             | _                                   | PropertyLocation.property
-        "stage"             | "null"              | _                                   | PropertyLocation.none
-        "versionScheme"     | "semver2"           | VersionScheme.semver2               | PropertyLocation.env
-        "versionScheme"     | "semver"            | VersionScheme.semver                | PropertyLocation.env
-        "versionScheme"     | "semver2"           | VersionScheme.semver2               | PropertyLocation.property
-        "versionScheme"     | "semver"            | VersionScheme.semver                | PropertyLocation.property
-        "versionCodeScheme" | "releaseCountBasic" | VersionCodeScheme.releaseCountBasic | PropertyLocation.env
-        "versionCodeScheme" | "releaseCount"      | VersionCodeScheme.releaseCount      | PropertyLocation.env
-        "versionCodeScheme" | "semver"            | VersionCodeScheme.semver            | PropertyLocation.env
-        "versionCodeScheme" | "none"              | VersionCodeScheme.none              | PropertyLocation.env
-        "versionCodeScheme" | "releaseCountBasic" | VersionCodeScheme.releaseCountBasic | PropertyLocation.property
-        "versionCodeScheme" | "releaseCount"      | VersionCodeScheme.releaseCount      | PropertyLocation.property
-        "versionCodeScheme" | "semver"            | VersionCodeScheme.semver            | PropertyLocation.property
-        "versionCodeScheme" | "none"              | VersionCodeScheme.none              | PropertyLocation.property
-        "versionCodeOffset" | 100                 | _                                   | PropertyLocation.env
-        "versionCodeOffset" | 200                 | _                                   | PropertyLocation.property
+        property               | value               | expectedValue                       | location
+        "scope"                | "major"             | ChangeScope.MAJOR                   | PropertyLocation.env
+        "scope"                | "MAJOR"             | ChangeScope.MAJOR                   | PropertyLocation.env
+        "scope"                | "Major"             | ChangeScope.MAJOR                   | PropertyLocation.env
+        "scope"                | "minor"             | ChangeScope.MINOR                   | PropertyLocation.env
+        "scope"                | "MINOR"             | ChangeScope.MINOR                   | PropertyLocation.env
+        "scope"                | "Minor"             | ChangeScope.MINOR                   | PropertyLocation.env
+        "scope"                | "patch"             | ChangeScope.PATCH                   | PropertyLocation.env
+        "scope"                | "PATCH"             | ChangeScope.PATCH                   | PropertyLocation.env
+        "scope"                | "Patch"             | ChangeScope.PATCH                   | PropertyLocation.env
+        "scope"                | "major"             | ChangeScope.MAJOR                   | PropertyLocation.property
+        "scope"                | "MAJOR"             | ChangeScope.MAJOR                   | PropertyLocation.property
+        "scope"                | "Major"             | ChangeScope.MAJOR                   | PropertyLocation.property
+        "scope"                | "minor"             | ChangeScope.MINOR                   | PropertyLocation.property
+        "scope"                | "MINOR"             | ChangeScope.MINOR                   | PropertyLocation.property
+        "scope"                | "Minor"             | ChangeScope.MINOR                   | PropertyLocation.property
+        "scope"                | "patch"             | ChangeScope.PATCH                   | PropertyLocation.property
+        "scope"                | "PATCH"             | ChangeScope.PATCH                   | PropertyLocation.property
+        "scope"                | "Patch"             | ChangeScope.PATCH                   | PropertyLocation.property
+        "scope"                | "null"              | _                                   | PropertyLocation.none
+        "stage"                | "snapshot"          | _                                   | PropertyLocation.env
+        "stage"                | "final"             | _                                   | PropertyLocation.property
+        "stage"                | "null"              | _                                   | PropertyLocation.none
+        "versionScheme"        | "semver2"           | VersionScheme.semver2               | PropertyLocation.env
+        "versionScheme"        | "semver"            | VersionScheme.semver                | PropertyLocation.env
+        "versionScheme"        | "semver2"           | VersionScheme.semver2               | PropertyLocation.property
+        "versionScheme"        | "semver"            | VersionScheme.semver                | PropertyLocation.property
+        "versionCodeScheme"    | "releaseCountBasic" | VersionCodeScheme.releaseCountBasic | PropertyLocation.env
+        "versionCodeScheme"    | "releaseCount"      | VersionCodeScheme.releaseCount      | PropertyLocation.env
+        "versionCodeScheme"    | "semver"            | VersionCodeScheme.semver            | PropertyLocation.env
+        "versionCodeScheme"    | "none"              | VersionCodeScheme.none              | PropertyLocation.env
+        "versionCodeScheme"    | "releaseCountBasic" | VersionCodeScheme.releaseCountBasic | PropertyLocation.property
+        "versionCodeScheme"    | "releaseCount"      | VersionCodeScheme.releaseCount      | PropertyLocation.property
+        "versionCodeScheme"    | "semver"            | VersionCodeScheme.semver            | PropertyLocation.property
+        "versionCodeScheme"    | "none"              | VersionCodeScheme.none              | PropertyLocation.property
+        "versionCodeOffset"    | 100                 | _                                   | PropertyLocation.env
+        "versionCodeOffset"    | 200                 | _                                   | PropertyLocation.property
+        "releaseBranchPattern" | /^m.*/              | _                                   | PropertyLocation.property
+        "releaseBranchPattern" | /(some|value)/      | _                                   | PropertyLocation.env
+        "releaseBranchPattern" | '/.*/'              | /.*/                                | PropertyLocation.script
+        "mainBranchPattern"    | /^m.*/              | _                                   | PropertyLocation.property
+        "mainBranchPattern"    | /(some|value)/      | _                                   | PropertyLocation.env
+        "mainBranchPattern"    | '/.*/'              | /.*/                                | PropertyLocation.script
 
         extensionName = "versionBuilder"
         testValue = (expectedValue == _) ? value : expectedValue
@@ -162,31 +168,47 @@ class VersionPluginIntegrationSpec extends IntegrationSpec {
         result.standardOutput.contains("${extensionName}.${property}: ${rawValue}")
 
         where:
-        property            | method                  | rawValue                            | type
-        "versionScheme"     | "versionScheme"         | "semver"                            | "String"
-        "versionScheme"     | "versionScheme"         | VersionScheme.semver2               | "VersionScheme"
-        "versionScheme"     | "versionScheme"         | VersionScheme.semver                | "Provider<VersionScheme>"
-        "versionScheme"     | "versionScheme.set"     | VersionScheme.semver2               | "VersionScheme"
-        "versionScheme"     | "versionScheme.set"     | VersionScheme.semver                | "Provider<VersionScheme>"
-        "versionScheme"     | "setVersionScheme"      | "semver"                            | "String"
-        "versionScheme"     | "setVersionScheme"      | VersionScheme.semver2               | "VersionScheme"
-        "versionScheme"     | "setVersionScheme"      | VersionScheme.semver                | "Provider<VersionScheme>"
+        property               | method                     | rawValue                            | type
+        "versionScheme"        | "versionScheme"            | "semver"                            | "String"
+        "versionScheme"        | "versionScheme"            | VersionScheme.semver2               | "VersionScheme"
+        "versionScheme"        | "versionScheme"            | VersionScheme.semver                | "Provider<VersionScheme>"
+        "versionScheme"        | "versionScheme"            | VersionScheme.staticMarker          | "Provider<VersionScheme>"
+        "versionScheme"        | "versionScheme.set"        | VersionScheme.semver2               | "VersionScheme"
+        "versionScheme"        | "versionScheme.set"        | VersionScheme.semver                | "Provider<VersionScheme>"
+        "versionScheme"        | "versionScheme.set"        | VersionScheme.staticMarker          | "Provider<VersionScheme>"
+        "versionScheme"        | "setVersionScheme"         | "semver"                            | "String"
+        "versionScheme"        | "setVersionScheme"         | VersionScheme.semver2               | "VersionScheme"
+        "versionScheme"        | "setVersionScheme"         | VersionScheme.semver                | "Provider<VersionScheme>"
 
-        "versionCodeScheme" | "versionCodeScheme"     | "releaseCountBasic"                 | "String"
-        "versionCodeScheme" | "versionCodeScheme"     | VersionCodeScheme.semver            | "VersionCodeScheme"
-        "versionCodeScheme" | "versionCodeScheme"     | VersionCodeScheme.releaseCountBasic | "Provider<VersionCodeScheme>"
-        "versionCodeScheme" | "versionCodeScheme.set" | VersionCodeScheme.semver            | "VersionCodeScheme"
-        "versionCodeScheme" | "versionCodeScheme.set" | VersionCodeScheme.releaseCountBasic | "Provider<VersionCodeScheme>"
-        "versionCodeScheme" | "setVersionCodeScheme"  | "releaseCount"                      | "String"
-        "versionCodeScheme" | "setVersionCodeScheme"  | VersionCodeScheme.none              | "VersionCodeScheme"
-        "versionCodeScheme" | "setVersionCodeScheme"  | VersionCodeScheme.releaseCount      | "Provider<VersionCodeScheme>"
+        "versionCodeScheme"    | "versionCodeScheme"        | "releaseCountBasic"                 | "String"
+        "versionCodeScheme"    | "versionCodeScheme"        | VersionCodeScheme.semver            | "VersionCodeScheme"
+        "versionCodeScheme"    | "versionCodeScheme"        | VersionCodeScheme.releaseCountBasic | "Provider<VersionCodeScheme>"
+        "versionCodeScheme"    | "versionCodeScheme.set"    | VersionCodeScheme.semver            | "VersionCodeScheme"
+        "versionCodeScheme"    | "versionCodeScheme.set"    | VersionCodeScheme.releaseCountBasic | "Provider<VersionCodeScheme>"
+        "versionCodeScheme"    | "setVersionCodeScheme"     | "releaseCount"                      | "String"
+        "versionCodeScheme"    | "setVersionCodeScheme"     | VersionCodeScheme.none              | "VersionCodeScheme"
+        "versionCodeScheme"    | "setVersionCodeScheme"     | VersionCodeScheme.releaseCount      | "Provider<VersionCodeScheme>"
 
-        "versionCodeOffset" | "versionCodeOffset"     | 1                                   | "Integer"
-        "versionCodeOffset" | "versionCodeOffset"     | 2                                   | "Provider<Integer>"
-        "versionCodeOffset" | "versionCodeOffset.set" | 3                                   | "Integer"
-        "versionCodeOffset" | "versionCodeOffset.set" | 4                                   | "Provider<Integer>"
-        "versionCodeOffset" | "setVersionCodeOffset"  | 5                                   | "Integer"
-        "versionCodeOffset" | "setVersionCodeOffset"  | 6                                   | "Provider<Integer>"
+        "versionCodeOffset"    | "versionCodeOffset"        | 1                                   | "Integer"
+        "versionCodeOffset"    | "versionCodeOffset"        | 2                                   | "Provider<Integer>"
+        "versionCodeOffset"    | "versionCodeOffset.set"    | 3                                   | "Integer"
+        "versionCodeOffset"    | "versionCodeOffset.set"    | 4                                   | "Provider<Integer>"
+        "versionCodeOffset"    | "setVersionCodeOffset"     | 5                                   | "Integer"
+        "versionCodeOffset"    | "setVersionCodeOffset"     | 6                                   | "Provider<Integer>"
+
+        "releaseBranchPattern" | "releaseBranchPattern"     | /.*/                                | "String"
+        "releaseBranchPattern" | "releaseBranchPattern"     | /(some|value)/                      | "Provider<String>"
+        "releaseBranchPattern" | "releaseBranchPattern.set" | /[a-z]/                             | "String"
+        "releaseBranchPattern" | "releaseBranchPattern.set" | /[0-9]/                             | "Provider<String>"
+        "releaseBranchPattern" | "setReleaseBranchPattern"  | /[alto]-[sierra]/                   | "String"
+        "releaseBranchPattern" | "setReleaseBranchPattern"  | /[whooom]/                          | "Provider<String>"
+
+        "mainBranchPattern"    | "mainBranchPattern"        | /.*/                                | "String"
+        "mainBranchPattern"    | "mainBranchPattern"        | /(some|value)/                      | "Provider<String>"
+        "mainBranchPattern"    | "mainBranchPattern.set"    | /[a-z]/                             | "String"
+        "mainBranchPattern"    | "mainBranchPattern.set"    | /[0-9]/                             | "Provider<String>"
+        "mainBranchPattern"    | "setMainBranchPattern"     | /[alto]-[sierra]/                   | "String"
+        "mainBranchPattern"    | "setMainBranchPattern"     | /[whooom]/                          | "Provider<String>"
 
         value = wrapValueBasedOnType(rawValue, type)
         extensionName = "versionBuilder"

--- a/src/main/groovy/wooga/gradle/version/VersionConsts.groovy
+++ b/src/main/groovy/wooga/gradle/version/VersionConsts.groovy
@@ -22,6 +22,9 @@ class VersionConsts {
     static final String GIT_ROOT_PROPERTY = "git.root"
     static final String UNINITIALIZED_VERSION = '0.1.0-dev.0.uninitialized'
 
+    static final String DEFAULT_MAIN_BRANCH_PATTERN = /(^master$|^develop$)/
+    static final String DEFAULT_RELEASE_BRANCH_PATTERN = /(^release\/.*|^master$)/
+
     static final VersionScheme VERSION_SCHEME_DEFAULT = VersionScheme.semver
     static final VersionCodeScheme VERSION_CODE_SCHEME_DEFAULT = VersionCodeScheme.none
 
@@ -43,4 +46,10 @@ class VersionConsts {
 
     static final String VERSION_STAGE_OPTION = "versionBuilder.stage"
     static final String VERSION_STAGE_ENV_VAR = "VERSION_BUILDER_STAGE"
+
+    static final String RELEASE_BRANCH_PATTERN_OPTION = "versionBuilder.releaseBranchPattern"
+    static final String RELEASE_BRANCH_PATTERN_ENV_VAR = "VERSION_BUILDER_RELEASE_BRANCH_PATTERN"
+
+    static final String MAIN_BRANCH_PATTERN_OPTION = "versionBuilder.mainBranchPattern"
+    static final String MAIN_BRANCH_PATTERN_ENV_VAR = "VERSION_BUILDER_MAIN_BRANCH_PATTERN"
 }

--- a/src/main/groovy/wooga/gradle/version/VersionPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/version/VersionPluginExtension.groovy
@@ -49,6 +49,18 @@ interface VersionPluginExtension {
     void setVersionCodeOffset(Integer value)
     void setVersionCodeOffset(Provider<Integer> value)
 
+    Property<String> getReleaseBranchPattern()
+    void releaseBranchPattern(String value)
+    void releaseBranchPattern(Provider<String> value)
+    void setReleaseBranchPattern(String value)
+    void setReleaseBranchPattern(Provider<String> value)
+
+    Property<String> getMainBranchPattern()
+    void mainBranchPattern(String value)
+    void mainBranchPattern(Provider<String> value)
+    void setMainBranchPattern(String value)
+    void setMainBranchPattern(Provider<String> value)
+
     Property<Grgit> getGit()
 
     Provider<ReleaseVersion> getVersion()

--- a/src/main/groovy/wooga/gradle/version/VersionScheme.groovy
+++ b/src/main/groovy/wooga/gradle/version/VersionScheme.groovy
@@ -19,7 +19,7 @@
 package wooga.gradle.version
 
 enum VersionScheme {
-    semver, semver2
+    semver, semver2, staticMarker
 }
 
 

--- a/src/main/groovy/wooga/gradle/version/internal/release/base/MarkerTagStrategy.groovy
+++ b/src/main/groovy/wooga/gradle/version/internal/release/base/MarkerTagStrategy.groovy
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2018-2020 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package wooga.gradle.version.internal.release.base
+
+import com.github.zafarkhaja.semver.ParseException
+import com.github.zafarkhaja.semver.Version
+import org.ajoberstar.grgit.Tag
+
+class MarkerTagStrategy extends TagStrategy {
+
+    private final String prefix
+
+    Closure<Version> parseTag = { Tag tag ->
+        try {
+            if(tag.name.startsWith(prefix)) {
+                Version.valueOf(tag.name.replace(prefix,""))
+            } else
+            {
+                null
+            }
+
+        } catch (ParseException e) {
+            null
+        }
+    }
+
+    MarkerTagStrategy(String prefix) {
+        super(false)
+        this.prefix = prefix
+    }
+}

--- a/src/main/groovy/wooga/gradle/version/internal/release/semver/SemVerStrategyState.groovy
+++ b/src/main/groovy/wooga/gradle/version/internal/release/semver/SemVerStrategyState.groovy
@@ -22,6 +22,7 @@ import com.github.zafarkhaja.semver.Version
 
 import org.ajoberstar.grgit.Branch
 import org.ajoberstar.grgit.Commit
+import org.ajoberstar.grgit.Tag
 
 /**
  * Working state used by {@link PartialSemVerStrategy}.
@@ -38,6 +39,11 @@ final class SemVerStrategyState {
     String inferredNormal
     String inferredPreRelease
     String inferredBuildMetadata
+    NearestVersion nearestCiMarker
+    NearestVersion nearestReleaseMarker
+
+    String releaseBranchPattern
+    String mainBranchPattern
 
     Version toVersion() {
         return new Version.Builder().with {

--- a/src/main/groovy/wooga/gradle/version/strategies/SemverV1Strategies.groovy
+++ b/src/main/groovy/wooga/gradle/version/strategies/SemverV1Strategies.groovy
@@ -195,6 +195,7 @@ class SemverV1Strategies {
                 if( branchName != "master") {
                     branchName = "$prefix${branchName.capitalize()}"
                 }
+
                 branchName = branchName.replaceAll(/(\/|-|_)([\w])/) {all, delimiter, firstAfter -> "${firstAfter.capitalize()}" }
                 branchName = branchName.replaceAll(/\./, "Dot")
                 branchName = branchName.replaceAll(/0/, "Zero")


### PR DESCRIPTION
## Description

This new strategy won't auto increment the normal part of the version as `semver` or `semver2` would do. Instead the whole normal part of the version is taken from a `marker` tag. Other metadata information for prerelease versions are generated in a similar fashion than done in the `semver` strategies but not based on the latest release tag but also on the marker tag.

One can define two marker tags in the project.

* `ci-0.0.0`
* `release-0.0.0`

The prefix can not be configured at the moment. The version strategy will look for these markers and determine the normal of the generated version. We have two different markers depending on the current release cycle. We can configure to use a specific marker based on the current git branch. This can be configured with the `releaseBranchPattern` property which has a default value of `/(^release\/.*|^master$)/`. Which means if the current branch is named `master` or starts with `release/` then use the normal from the `release-*` marker tag. If not use the ci marker. This allows to bump the ci version to the next to be released version for development when the release process is kicked off in a sidebranch. To illustrate this:

```
         *     branch: 'develop', version: '0.2.0-develop.2
        /|
       ◊ |     branch: 'master', version: '0.1.0', tag: 'v0.1.0,
       | |
       * |     branch: 'master', version: '0.1.0-master.1, distance: 1
       | |
       | *     branch: 'develop', version: '0.2.0-develop.1
        \|
         ◊     branch: 'develop', version: '0.0.0', tag: 'release-0.1.0', ci-0.2.0,
```

Staging and production build generation works as before. Staging builds will increment based on the previous staging version.

This patch also adds a new configuration property which allows to configure which branch(es) are the main development branches. This information is used to construct the snapshot prerelease metadata.

A snapshot version gets constructed with the `normal version` + `encoded branchname` + `counter`.

The branchname comes in two flavors. If it is a main branch (`master`, `develop`) by default it won't be prefixed with `branch.` (depending on the semver strategy) Now it's possible to provide a patter for this check

`mainBranchPattern` the default value is `/(^master$|^develop$)/`

## Changes

* ![ADD] `staticMarker` version strategy


[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:https://atlas-resources.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:https://atlas-resources.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:https://atlas-resources.wooga.com/icons/icon_change.svg "Change"
[FIX]:https://atlas-resources.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:https://atlas-resources.wooga.com/icons/icon_update.svg "Update"

[BREAK]:https://atlas-resources.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:https://atlas-resources.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:https://atlas-resources.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:https://atlas-resources.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:https://atlas-resources.wooga.com/icons/icon_webGL.svg "Web:GL"
[GRADLE]:https://atlas-resources.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:https://atlas-resources.wooga.com/icons/icon_unity.svg "Unity"
