### PR TITLE
Fix jgit jdk8 compatibility issue

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,13 @@
  * limitations under the License.
  *
  */
+buildscript {
+    configurations.all {
+        resolutionStrategy {
+            force 'org.ajoberstar.grgit:grgit-core:4.1.1'
+        }
+    }
+}
 
 plugins {
     id 'net.wooga.plugins' version '2.2.0'
@@ -44,7 +51,7 @@ github {
 
 dependencies {
     compile 'com.github.zafarkhaja:java-semver:0.9.0'
-    compile 'org.ajoberstar.grgit:grgit-core:4.1.0'
+    compile 'org.ajoberstar.grgit:grgit-core:4.1.1'
     compile 'com.google.guava:guava:23.0'
     testCompile 'com.github.stefanbirkner:system-rules:1.18.0'
 }


### PR DESCRIPTION
## Description

This patch updates `grgit-core` to patch `4.1.1` which limits the version range of `jgit` to latest major version `5`. This allows this plugin to be used with jdk8 still. I also had to add an force resolution of `grgit-core:4.1.1` because the buildscript pulls a version of this plugin into the classpath. This should later be saved to remove

## Changes

* ![FIX] `jgit` jdk8 compatibility issue

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"