### PR TITLE
Add helper methods to get the release stage

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,9 @@ dependencies {
     implementation 'com.github.zafarkhaja:java-semver:0.9.0'
     implementation 'org.ajoberstar.grgit:grgit-core:4.1.1'
     implementation 'com.google.guava:guava:23.0'
-    implementation 'com.wooga.gradle:gradle-commons:(0.4,0.5]'
+    implementation 'com.wooga.gradle:gradle-commons:(1, 2]'
+
+    testImplementation 'com.wooga.gradle:gradle-commons-test:(1,2]'
     testImplementation 'com.github.stefanbirkner:system-rules:1.18.0'
 }
 

--- a/src/integrationTest/groovy/wooga/gradle/version/VersionIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/version/VersionIntegrationSpec.groovy
@@ -23,22 +23,7 @@ import nebula.test.functional.ExecutionResult
 import org.junit.contrib.java.lang.system.EnvironmentVariables
 import org.junit.contrib.java.lang.system.ProvideSystemProperty
 
-class IntegrationSpec extends nebula.test.IntegrationSpec {
-
-    @Rule
-    ProvideSystemProperty properties = new ProvideSystemProperty("ignoreDeprecations", "true")
-
-    @Rule
-    public final EnvironmentVariables environmentVariables = new EnvironmentVariables()
-
-    def escapedPath(String path) {
-        String osName = System.getProperty("os.name").toLowerCase()
-        if (osName.contains("windows")) {
-            path = StringEscapeUtils.escapeJava(path)
-            return path.replace('\\', '\\\\')
-        }
-        path
-    }
+class IntegrationSpec extends com.wooga.gradle.test.IntegrationSpec {
 
 
     def setup() {
@@ -47,14 +32,6 @@ class IntegrationSpec extends nebula.test.IntegrationSpec {
             this.gradleVersion = gradleVersion
             fork = true
         }
-
-        environmentVariables.clear(
-            // add env vars to clear before test.
-        )
-    }
-
-    Boolean outputContains(ExecutionResult result, String message) {
-        result.standardOutput.contains(message) || result.standardError.contains(message)
     }
 
     String wrapValueBasedOnType(Object rawValue, String type) {

--- a/src/integrationTest/groovy/wooga/gradle/version/VersionPluginIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/version/VersionPluginIntegrationSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2020 Wooga GmbH
+ * Copyright 2018-2022 Wooga GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,37 +12,20 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- *
  */
 
 package wooga.gradle.version
 
+import com.wooga.gradle.PlatformUtils
+import com.wooga.gradle.test.PropertyLocation
 import wooga.gradle.version.internal.release.semver.ChangeScope
 import spock.lang.Unroll
 
-class VersionPluginIntegrationSpec extends IntegrationSpec {
+class VersionPluginIntegrationSpec extends VersionIntegrationSpec {
     def setup() {
         buildFile << """
             ${applyPlugin(VersionPlugin)}
         """.stripIndent()
-    }
-
-    enum PropertyLocation {
-        none, script, property, env
-
-        String reason() {
-            switch (this) {
-                case script:
-                    return "value is provided in script"
-                case property:
-                    return "value is provided in props"
-                case env:
-                    return "value is set in env"
-                default:
-                    return "no value was configured"
-            }
-        }
     }
 
     String envNameFromProperty(String property) {
@@ -64,7 +47,7 @@ class VersionPluginIntegrationSpec extends IntegrationSpec {
         and: "a gradle.properties"
         def propertiesFile = createFile("gradle.properties")
 
-        def escapedValue = (value instanceof String) ? escapedPath(value) : value
+        def escapedValue = (value instanceof String) ? PlatformUtils.escapedPath(value) : value
 
         switch (location) {
             case PropertyLocation.script:
@@ -73,7 +56,7 @@ class VersionPluginIntegrationSpec extends IntegrationSpec {
             case PropertyLocation.property:
                 propertiesFile << "${extensionName}.${property} = ${escapedValue}"
                 break
-            case PropertyLocation.env:
+            case PropertyLocation.environment:
                 environmentVariables.set(envNameFromProperty(property), "${value}")
                 break
             default:
@@ -82,7 +65,7 @@ class VersionPluginIntegrationSpec extends IntegrationSpec {
 
         and: "the test value with replace placeholders"
         if (testValue instanceof String) {
-            testValue = testValue.replaceAll("#projectDir#", escapedPath(projectDir.path))
+            testValue = testValue.replaceAll("#projectDir#", PlatformUtils.escapedPath(projectDir.path))
         }
 
         when: ""
@@ -93,15 +76,15 @@ class VersionPluginIntegrationSpec extends IntegrationSpec {
 
         where:
         property               | value               | expectedValue                       | location
-        "scope"                | "major"             | ChangeScope.MAJOR                   | PropertyLocation.env
-        "scope"                | "MAJOR"             | ChangeScope.MAJOR                   | PropertyLocation.env
-        "scope"                | "Major"             | ChangeScope.MAJOR                   | PropertyLocation.env
-        "scope"                | "minor"             | ChangeScope.MINOR                   | PropertyLocation.env
-        "scope"                | "MINOR"             | ChangeScope.MINOR                   | PropertyLocation.env
-        "scope"                | "Minor"             | ChangeScope.MINOR                   | PropertyLocation.env
-        "scope"                | "patch"             | ChangeScope.PATCH                   | PropertyLocation.env
-        "scope"                | "PATCH"             | ChangeScope.PATCH                   | PropertyLocation.env
-        "scope"                | "Patch"             | ChangeScope.PATCH                   | PropertyLocation.env
+        "scope"                | "major"             | ChangeScope.MAJOR                   | PropertyLocation.environment
+        "scope"                | "MAJOR"             | ChangeScope.MAJOR                   | PropertyLocation.environment
+        "scope"                | "Major"             | ChangeScope.MAJOR                   | PropertyLocation.environment
+        "scope"                | "minor"             | ChangeScope.MINOR                   | PropertyLocation.environment
+        "scope"                | "MINOR"             | ChangeScope.MINOR                   | PropertyLocation.environment
+        "scope"                | "Minor"             | ChangeScope.MINOR                   | PropertyLocation.environment
+        "scope"                | "patch"             | ChangeScope.PATCH                   | PropertyLocation.environment
+        "scope"                | "PATCH"             | ChangeScope.PATCH                   | PropertyLocation.environment
+        "scope"                | "Patch"             | ChangeScope.PATCH                   | PropertyLocation.environment
         "scope"                | "major"             | ChangeScope.MAJOR                   | PropertyLocation.property
         "scope"                | "MAJOR"             | ChangeScope.MAJOR                   | PropertyLocation.property
         "scope"                | "Major"             | ChangeScope.MAJOR                   | PropertyLocation.property
@@ -112,28 +95,28 @@ class VersionPluginIntegrationSpec extends IntegrationSpec {
         "scope"                | "PATCH"             | ChangeScope.PATCH                   | PropertyLocation.property
         "scope"                | "Patch"             | ChangeScope.PATCH                   | PropertyLocation.property
         "scope"                | "null"              | _                                   | PropertyLocation.none
-        "stage"                | "snapshot"          | _                                   | PropertyLocation.env
+        "stage"                | "snapshot"          | _                                   | PropertyLocation.environment
         "stage"                | "final"             | _                                   | PropertyLocation.property
         "stage"                | "null"              | _                                   | PropertyLocation.none
-        "versionScheme"        | "semver2"           | VersionScheme.semver2               | PropertyLocation.env
-        "versionScheme"        | "semver"            | VersionScheme.semver                | PropertyLocation.env
+        "versionScheme"        | "semver2"           | VersionScheme.semver2               | PropertyLocation.environment
+        "versionScheme"        | "semver"            | VersionScheme.semver                | PropertyLocation.environment
         "versionScheme"        | "semver2"           | VersionScheme.semver2               | PropertyLocation.property
         "versionScheme"        | "semver"            | VersionScheme.semver                | PropertyLocation.property
-        "versionCodeScheme"    | "releaseCountBasic" | VersionCodeScheme.releaseCountBasic | PropertyLocation.env
-        "versionCodeScheme"    | "releaseCount"      | VersionCodeScheme.releaseCount      | PropertyLocation.env
-        "versionCodeScheme"    | "semver"            | VersionCodeScheme.semver            | PropertyLocation.env
-        "versionCodeScheme"    | "none"              | VersionCodeScheme.none              | PropertyLocation.env
+        "versionCodeScheme"    | "releaseCountBasic" | VersionCodeScheme.releaseCountBasic | PropertyLocation.environment
+        "versionCodeScheme"    | "releaseCount"      | VersionCodeScheme.releaseCount      | PropertyLocation.environment
+        "versionCodeScheme"    | "semver"            | VersionCodeScheme.semver            | PropertyLocation.environment
+        "versionCodeScheme"    | "none"              | VersionCodeScheme.none              | PropertyLocation.environment
         "versionCodeScheme"    | "releaseCountBasic" | VersionCodeScheme.releaseCountBasic | PropertyLocation.property
         "versionCodeScheme"    | "releaseCount"      | VersionCodeScheme.releaseCount      | PropertyLocation.property
         "versionCodeScheme"    | "semver"            | VersionCodeScheme.semver            | PropertyLocation.property
         "versionCodeScheme"    | "none"              | VersionCodeScheme.none              | PropertyLocation.property
-        "versionCodeOffset"    | 100                 | _                                   | PropertyLocation.env
+        "versionCodeOffset"    | 100                 | _                                   | PropertyLocation.environment
         "versionCodeOffset"    | 200                 | _                                   | PropertyLocation.property
         "releaseBranchPattern" | /^m.*/              | _                                   | PropertyLocation.property
-        "releaseBranchPattern" | /(some|value)/      | _                                   | PropertyLocation.env
+        "releaseBranchPattern" | /(some|value)/      | _                                   | PropertyLocation.environment
         "releaseBranchPattern" | '/.*/'              | /.*/                                | PropertyLocation.script
         "mainBranchPattern"    | /^m.*/              | _                                   | PropertyLocation.property
-        "mainBranchPattern"    | /(some|value)/      | _                                   | PropertyLocation.env
+        "mainBranchPattern"    | /(some|value)/      | _                                   | PropertyLocation.environment
         "mainBranchPattern"    | '/.*/'              | /.*/                                | PropertyLocation.script
 
         extensionName = "versionBuilder"
@@ -158,7 +141,7 @@ class VersionPluginIntegrationSpec extends IntegrationSpec {
 
         and: "the test value with replace placeholders"
         if (value instanceof String) {
-            value = value.replaceAll("#projectDir#", escapedPath(projectDir.path))
+            value = value.replaceAll("#projectDir#", PlatformUtils.escapedPath(projectDir.path))
         }
 
         when: ""

--- a/src/main/groovy/wooga/gradle/version/ReleaseStage.groovy
+++ b/src/main/groovy/wooga/gradle/version/ReleaseStage.groovy
@@ -1,0 +1,9 @@
+package wooga.gradle.version
+
+enum ReleaseStage {
+    Unknown,
+    Development,
+    Snapshot,
+    Prerelease,
+    Final,
+}

--- a/src/main/groovy/wooga/gradle/version/VersionPluginConventions.groovy
+++ b/src/main/groovy/wooga/gradle/version/VersionPluginConventions.groovy
@@ -25,37 +25,6 @@ class VersionPluginConventions {
     static final String GIT_ROOT_PROPERTY = "git.root"
     static final String UNINITIALIZED_VERSION = '0.1.0-dev.0.uninitialized'
 
-    static final String DEFAULT_MAIN_BRANCH_PATTERN = /(^master$|^develop$)/
-    static final String DEFAULT_RELEASE_BRANCH_PATTERN = /(^release\/.*|^master$)/
-
-    static final VersionScheme VERSION_SCHEME_DEFAULT = VersionScheme.semver
-    static final VersionCodeScheme VERSION_CODE_SCHEME_DEFAULT = VersionCodeScheme.none
-
-    static final String LEGACY_VERSION_SCHEME_OPTION = "version.scheme"
-    static final String LEGACY_VERSION_SCOPE_OPTION = "release.scope"
-    static final String LEGACY_VERSION_STAGE_OPTION = "release.stage"
-
-    static final String VERSION_SCHEME_OPTION = "versionBuilder.versionScheme"
-    static final String VERSION_SCHEME_ENV_VAR = "VERSION_BUILDER_VERSION_SCHEME"
-
-    static final String VERSION_CODE_SCHEME_OPTION = "versionBuilder.versionCodeScheme"
-    static final String VERSION_CODE_SCHEME_ENV_VAR = "VERSION_BUILDER_VERSION_CODE_SCHEME"
-
-    static final String VERSION_CODE_OFFSET_OPTION = "versionBuilder.versionCodeOffset"
-    static final String VERSION_CODE_OFFSET_ENV_VAR = "VERSION_BUILDER_VERSION_CODE_OFFSET"
-
-    static final String VERSION_SCOPE_OPTION = "versionBuilder.scope"
-    static final String VERSION_SCOPE_ENV_VAR = "VERSION_BUILDER_SCOPE"
-
-    static final String VERSION_STAGE_OPTION = "versionBuilder.stage"
-    static final String VERSION_STAGE_ENV_VAR = "VERSION_BUILDER_STAGE"
-
-    static final String RELEASE_BRANCH_PATTERN_OPTION = "versionBuilder.releaseBranchPattern"
-    static final String RELEASE_BRANCH_PATTERN_ENV_VAR = "VERSION_BUILDER_RELEASE_BRANCH_PATTERN"
-
-    static final String MAIN_BRANCH_PATTERN_OPTION = "versionBuilder.mainBranchPattern"
-    static final String MAIN_BRANCH_PATTERN_ENV_VAR = "VERSION_BUILDER_MAIN_BRANCH_PATTERN"
-
     static final PropertyLookup versionScheme = new PropertyLookup("VERSION_BUILDER_VERSION_SCHEME", ["versionBuilder.versionScheme", "version.scheme"], VersionScheme.semver)
     static final PropertyLookup versionCodeScheme = new PropertyLookup("VERSION_BUILDER_VERSION_CODE_SCHEME", "versionBuilder.versionCodeScheme", VersionCodeScheme.none)
     static final PropertyLookup versionCodeOffset = new PropertyLookup("VERSION_BUILDER_VERSION_CODE_OFFSET", "versionBuilder.versionCodeOffset", 0)

--- a/src/main/groovy/wooga/gradle/version/VersionPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/version/VersionPluginExtension.groovy
@@ -26,6 +26,8 @@ import wooga.gradle.version.internal.release.semver.ChangeScope
 import org.ajoberstar.grgit.Grgit
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
+import wooga.gradle.version.internal.release.semver.SemVerStrategy
+import wooga.gradle.version.internal.release.semver.SemVerStrategyState
 import wooga.gradle.version.strategies.SemverV2Strategies
 
 trait VersionPluginExtension implements BaseSpec {
@@ -216,7 +218,11 @@ trait VersionPluginExtension implements BaseSpec {
     Provider<String> stage = objects.property(String)
 
     void setStage(Provider<String> value) {
-        stage = value
+        stage.set(value)
+    }
+
+    void setStage(String value) {
+        stage.set(value)
     }
 
     /**
@@ -301,23 +307,18 @@ trait VersionPluginExtension implements BaseSpec {
     }
 
     final Provider<ReleaseStage> releaseStage = providers.provider({
-        if (isDevelopment.get()) {
+        if (isDevelopment.getOrElse(false)) {
             return ReleaseStage.Development
-        } else if (isSnapshot.get()) {
+        } else if (isSnapshot.getOrElse(false)) {
             return ReleaseStage.Snapshot
-        } else if (isPrerelease.get()) {
+        } else if (isPrerelease.getOrElse(false)) {
             return ReleaseStage.Prerelease
-        } else if (isFinal.get()) {
+        } else if (isFinal.getOrElse(false)) {
             return ReleaseStage.Final
         }
-        return ReleaseStage.Unknown
+        ReleaseStage.Unknown
     })
+
+    final ReleaseStage defaultReleaseStage
 }
 
-enum ReleaseStage {
-    Development,
-    Snapshot,
-    Prerelease,
-    Final,
-    Unknown
-}

--- a/src/main/groovy/wooga/gradle/version/VersionPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/version/VersionPluginExtension.groovy
@@ -19,12 +19,14 @@
 package wooga.gradle.version
 
 import com.wooga.gradle.BaseSpec
+import org.gradle.api.provider.ProviderFactory
 import wooga.gradle.version.internal.release.base.ReleaseVersion
 import wooga.gradle.version.internal.release.base.TagStrategy
 import wooga.gradle.version.internal.release.semver.ChangeScope
 import org.ajoberstar.grgit.Grgit
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
+import wooga.gradle.version.strategies.SemverV2Strategies
 
 trait VersionPluginExtension implements BaseSpec {
 
@@ -97,7 +99,7 @@ trait VersionPluginExtension implements BaseSpec {
     /**
      * @return If set, used during the evaluation of {@code versionCode}
      */
-    Property<Integer> getVersionCodeOffset(){
+    Property<Integer> getVersionCodeOffset() {
         versionCodeOffset
     }
 
@@ -187,7 +189,7 @@ trait VersionPluginExtension implements BaseSpec {
 
     private Provider<ReleaseVersion> version
 
-    void setVersion(Provider<ReleaseVersion> value){
+    void setVersion(Provider<ReleaseVersion> value) {
         version = value
     }
 
@@ -238,4 +240,84 @@ trait VersionPluginExtension implements BaseSpec {
     }
 
     TagStrategy tagStrategy = new TagStrategy()
+
+    /**
+     * @return Whether this is a development build
+     */
+    Provider<Boolean> getIsDevelopment() {
+        isDevelopment
+    }
+
+    void setIsDevelopment(Provider<Boolean> value) {
+        isDevelopment = value
+    }
+
+    Provider<Boolean> isDevelopment
+
+    /**
+     * @return Whether this is a production build
+     */
+    Provider<Boolean> getIsFinal() {
+        isFinal
+    }
+
+    Provider<Boolean> isFinal
+
+    void setIsFinal(Provider<Boolean> value) {
+        isFinal = value
+    }
+
+    /**
+     * @return Whether this is a pre-release build
+     */
+    Provider<Boolean> getIsPrerelease() {
+        isPrerelease
+    }
+
+    Provider<Boolean> isPrerelease
+
+    void setIsPrerelease(Provider<Boolean> value) {
+        isPrerelease = value
+    }
+
+    /**
+     * @return Whether this is a snapshot build (such as from a CI environment)
+     */
+    Provider<Boolean> getIsSnapshot() {
+        isSnapshot
+    }
+
+    Provider<Boolean> isSnapshot
+
+    void setIsSnapshot(Provider<Boolean> value) {
+        isSnapshot = value
+    }
+
+    /**
+     * @return The deduced release stage for this build
+     */
+    Provider<ReleaseStage> getReleaseStage() {
+        releaseStage
+    }
+
+    final Provider<ReleaseStage> releaseStage = providers.provider({
+        if (isDevelopment.get()) {
+            return ReleaseStage.Development
+        } else if (isSnapshot.get()) {
+            return ReleaseStage.Snapshot
+        } else if (isPrerelease.get()) {
+            return ReleaseStage.Prerelease
+        } else if (isFinal.get()) {
+            return ReleaseStage.Final
+        }
+        return ReleaseStage.Unknown
+    })
+}
+
+enum ReleaseStage {
+    Development,
+    Snapshot,
+    Prerelease,
+    Final,
+    Unknown
 }

--- a/src/main/groovy/wooga/gradle/version/internal/DefaultVersionPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/version/internal/DefaultVersionPluginExtension.groovy
@@ -18,6 +18,7 @@
 
 package wooga.gradle.version.internal
 
+import wooga.gradle.version.ReleaseStage
 import wooga.gradle.version.VersionCodeScheme
 import wooga.gradle.version.VersionScheme
 import wooga.gradle.version.internal.release.base.DefaultVersionStrategy
@@ -43,6 +44,7 @@ class DefaultVersionPluginExtension implements VersionPluginExtension {
     protected final Property<VersionStrategy> preReleaseStrategy
     protected final Property<VersionStrategy> finalStrategy
     protected final Property<VersionStrategy> defaultStrategy
+
 
     final Provider<List<VersionStrategy>> versionStrategies
 
@@ -177,5 +179,21 @@ class DefaultVersionPluginExtension implements VersionPluginExtension {
                     0
             }
         }.memoize())
+
+        // TODO: Test these providers are resolved correctly
+        // Set up providers to evaluate the release stage of a project,
+        // which  can be used by client projects
+        isDevelopment = developmentStrategy.map({
+            it.stages.contains(this.stage.get())
+        })
+        isSnapshot = snapshotStrategy.map({
+            it.stages.contains(this.stage.get())
+        })
+        isPrerelease = preReleaseStrategy.map({
+            it.stages.contains(this.stage.get())
+        })
+        isFinal = finalStrategy.map({
+            it.stages.contains(this.stage.get())
+        })
     }
 }

--- a/src/main/groovy/wooga/gradle/version/internal/release/base/VersionStrategy.groovy
+++ b/src/main/groovy/wooga/gradle/version/internal/release/base/VersionStrategy.groovy
@@ -18,6 +18,7 @@ package wooga.gradle.version.internal.release.base
 import org.ajoberstar.grgit.Grgit
 
 import org.gradle.api.Project
+import wooga.gradle.version.ReleaseStage
 
 /**
  * Strategy to infer a version from the project's and Git repository's state.
@@ -53,4 +54,9 @@ interface VersionStrategy {
      * The stages supported by this strategy.
      */
     SortedSet<String> getStages()
+
+    /**
+     * @return The release stage by this strategy
+     */
+    ReleaseStage getReleaseStage()
 }

--- a/src/main/groovy/wooga/gradle/version/internal/release/base/VersionStrategy.groovy
+++ b/src/main/groovy/wooga/gradle/version/internal/release/base/VersionStrategy.groovy
@@ -48,4 +48,9 @@ interface VersionStrategy {
      * @return the inferred version
      */
     ReleaseVersion infer(Project project, Grgit grgit)
+
+    /**
+     * The stages supported by this strategy.
+     */
+    SortedSet<String> getStages()
 }

--- a/src/main/groovy/wooga/gradle/version/internal/release/opinion/Strategies.groovy
+++ b/src/main/groovy/wooga/gradle/version/internal/release/opinion/Strategies.groovy
@@ -15,6 +15,7 @@
  */
 package wooga.gradle.version.internal.release.opinion
 
+import wooga.gradle.version.ReleaseStage
 import wooga.gradle.version.internal.release.semver.ChangeScope
 import wooga.gradle.version.internal.release.semver.SemVerStrategyState
 
@@ -180,7 +181,7 @@ final class Strategies {
 
         static final PartialSemVerStrategy USE_MARKER_TAG = closure { SemVerStrategyState state ->
             def markerVersion = state.nearestCiMarker
-            if(state.currentBranch.name.matches(state.releaseBranchPattern)) {
+            if (state.currentBranch.name.matches(state.releaseBranchPattern)) {
                 markerVersion = state.nearestReleaseMarker
             }
             state = state.copyWith(inferredNormal: markerVersion.normal)
@@ -200,7 +201,7 @@ final class Strategies {
         /**
          * Sets the pre-release component to the value of {@link SemVerStrategyState#stageFromProp}.
          */
-        static final PartialSemVerStrategy STAGE_FIXED = closure { state -> state.copyWith(inferredPreRelease: state.stageFromProp)}
+        static final PartialSemVerStrategy STAGE_FIXED = closure { state -> state.copyWith(inferredPreRelease: state.stageFromProp) }
 
         /**
          * If the value of {@link SemVerStrategyState#stageFromProp} has a higher or the same precedence than
@@ -265,7 +266,7 @@ final class Strategies {
 
         static final PartialSemVerStrategy COUNT_COMMITS_SINCE_MARKER = closure { SemVerStrategyState state ->
             def markerVersion = state.nearestCiMarker
-            if(state.currentBranch.name.matches(state.releaseBranchPattern)) {
+            if (state.currentBranch.name.matches(state.releaseBranchPattern)) {
                 markerVersion = state.nearestReleaseMarker
             }
 
@@ -310,7 +311,8 @@ final class Strategies {
         preReleaseStrategy: PreRelease.NONE,
         buildMetadataStrategy: BuildMetadata.NONE,
         createTag: true,
-        enforcePrecedence: true
+        enforcePrecedence: true,
+        releaseStage: ReleaseStage.Unknown
     )
 
     /**
@@ -324,7 +326,8 @@ final class Strategies {
         allowDirtyRepo: true,
         preReleaseStrategy: PreRelease.STAGE_FIXED,
         createTag: false,
-        enforcePrecedence: false
+        enforcePrecedence: false,
+        releaseStage: ReleaseStage.Snapshot
     )
 
     /**
@@ -342,7 +345,8 @@ final class Strategies {
         allowDirtyRepo: true,
         preReleaseStrategy: all(PreRelease.STAGE_FLOAT, PreRelease.COUNT_COMMITS_SINCE_ANY, PreRelease.SHOW_UNCOMMITTED),
         buildMetadataStrategy: BuildMetadata.COMMIT_ABBREVIATED_ID,
-        createTag: false
+        createTag: false,
+        releaseStage: ReleaseStage.Development
     )
 
     /**
@@ -356,7 +360,8 @@ final class Strategies {
     static final SemVerStrategy PRE_RELEASE = DEFAULT.copyWith(
         name: 'pre-release',
         stages: ['milestone', 'rc'] as SortedSet,
-        preReleaseStrategy: all(PreRelease.STAGE_FIXED, PreRelease.COUNT_INCREMENTED)
+        preReleaseStrategy: all(PreRelease.STAGE_FIXED, PreRelease.COUNT_INCREMENTED),
+        releaseStage: ReleaseStage.Prerelease
     )
 
     /**
@@ -369,7 +374,8 @@ final class Strategies {
      */
     static final SemVerStrategy PRE_RELEASE_ALPHA_BETA = PRE_RELEASE.copyWith(
         name: 'pre-release',
-        stages: ['alpha', 'beta', 'rc'] as SortedSet
+        stages: ['alpha', 'beta', 'rc'] as SortedSet,
+        releaseStage: ReleaseStage.Prerelease
     )
 
     /**
@@ -379,6 +385,7 @@ final class Strategies {
      */
     static final SemVerStrategy FINAL = DEFAULT.copyWith(
         name: 'final',
-        stages: ['final'] as SortedSet
+        stages: ['final'] as SortedSet,
+        releaseStage: ReleaseStage.Final
     )
 }

--- a/src/main/groovy/wooga/gradle/version/internal/release/semver/SemVerStrategy.groovy
+++ b/src/main/groovy/wooga/gradle/version/internal/release/semver/SemVerStrategy.groovy
@@ -19,6 +19,7 @@ import groovy.transform.Immutable
 import groovy.transform.PackageScope
 
 import com.github.zafarkhaja.semver.Version
+import wooga.gradle.version.ReleaseStage
 import wooga.gradle.version.internal.release.base.MarkerTagStrategy
 import wooga.gradle.version.internal.release.base.ReleaseVersion
 import wooga.gradle.version.internal.release.base.DefaultVersionStrategy
@@ -55,6 +56,8 @@ final class SemVerStrategy implements DefaultVersionStrategy {
      * Whether or not this strategy can be used if the repo has uncommited changes.
      */
     boolean allowDirtyRepo
+
+    ReleaseStage releaseStage
 
     /**
      * The strategy used to infer the normal component of the version. There is no enforcement that

--- a/src/main/groovy/wooga/gradle/version/strategies/SemverV2Strategies.groovy
+++ b/src/main/groovy/wooga/gradle/version/strategies/SemverV2Strategies.groovy
@@ -17,7 +17,7 @@
 
 package wooga.gradle.version.strategies
 
-
+import wooga.gradle.version.ReleaseStage
 import wooga.gradle.version.internal.release.opinion.Strategies
 import wooga.gradle.version.internal.release.opinion.Strategies.BuildMetadata
 import wooga.gradle.version.internal.release.semver.ChangeScope
@@ -94,7 +94,8 @@ final class SemverV2Strategies {
             preReleaseStrategy: Strategies.PreRelease.NONE,
             buildMetadataStrategy: BuildMetadata.NONE,
             createTag: true,
-            enforcePrecedence: true
+            enforcePrecedence: true,
+            releaseStage: ReleaseStage.Unknown
     )
 
     /**
@@ -113,8 +114,8 @@ final class SemverV2Strategies {
      */
     static final SemVerStrategy FINAL = DEFAULT.copyWith(
             name: 'production',
-
-            stages: ['final','production'] as SortedSet
+            stages: ['final','production'] as SortedSet,
+            releaseStage: ReleaseStage.Final
     )
 
     /**
@@ -156,7 +157,8 @@ final class SemverV2Strategies {
     static final SemVerStrategy PRE_RELEASE = DEFAULT.copyWith(
             name: 'pre-release',
             stages: ['rc', 'staging'] as SortedSet,
-            preReleaseStrategy: all(Strategies.PreRelease.STAGE_FIXED, Strategies.PreRelease.COUNT_INCREMENTED)
+            preReleaseStrategy: all(Strategies.PreRelease.STAGE_FIXED, Strategies.PreRelease.COUNT_INCREMENTED),
+            releaseStage: ReleaseStage.Prerelease
     )
 
     /**
@@ -180,7 +182,8 @@ final class SemverV2Strategies {
      */
     static final SemVerStrategy DEVELOPMENT = Strategies.DEVELOPMENT.copyWith(
             normalStrategy: scopes,
-            buildMetadataStrategy: NetflixOssStrategies.BuildMetadata.DEVELOPMENT_METADATA_STRATEGY)
+            buildMetadataStrategy: NetflixOssStrategies.BuildMetadata.DEVELOPMENT_METADATA_STRATEGY
+    )
 
     /**
      * Returns a version strategy to be used for {@code snapshot} builds.
@@ -215,6 +218,7 @@ final class SemverV2Strategies {
             stages: ['ci', 'snapshot', 'SNAPSHOT'] as SortedSet,
             createTag: false,
             preReleaseStrategy: all(PreRelease.STAGE_BRANCH_NAME, Strategies.PreRelease.COUNT_COMMITS_SINCE_ANY),
-            enforcePrecedence: false
+            enforcePrecedence: false,
+            releaseStage: ReleaseStage.Snapshot
     )
 }


### PR DESCRIPTION
## Description

Add helper methods to get the release stage (dev, rc, snapshot, final). This is useful for writing predicates and the like.

## Changes
* ![ADD] Providers in the extension to get the current release stage resolved by the plugin.
 
[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"
