### PR TITLE
Add prefight release stage

### DIFF
--- a/src/main/groovy/wooga/gradle/version/ReleaseStage.groovy
+++ b/src/main/groovy/wooga/gradle/version/ReleaseStage.groovy
@@ -1,9 +1,29 @@
 package wooga.gradle.version
 
 enum ReleaseStage {
+    /**
+     * Used to denote a release that was not able to be deduced
+     */
     Unknown,
+    /**
+     * The default release
+     */
     Development,
+    /**
+     * A release that is conventionally produced by a CI pipeline.
+     * (It generally uses a counter from the branch and the number of commits since the last tag)
+     */
     Snapshot,
+    /**
+     * A release that is mainly used for internal integration testing
+     */
+    Preflight,
+    /**
+     * A release for early adopters
+     */
     Prerelease,
+    /**
+     * A published release with a high degree of confidence
+     */
     Final,
 }

--- a/src/main/groovy/wooga/gradle/version/VersionScheme.groovy
+++ b/src/main/groovy/wooga/gradle/version/VersionScheme.groovy
@@ -19,7 +19,7 @@
 package wooga.gradle.version
 
 enum VersionScheme {
-    semver, semver2, staticMarker
+    semver, semver2, staticMarker, wdk
 }
 
 

--- a/src/main/groovy/wooga/gradle/version/internal/release/opinion/Strategies.groovy
+++ b/src/main/groovy/wooga/gradle/version/internal/release/opinion/Strategies.groovy
@@ -19,6 +19,9 @@ import wooga.gradle.version.ReleaseStage
 import wooga.gradle.version.internal.release.semver.ChangeScope
 import wooga.gradle.version.internal.release.semver.SemVerStrategyState
 
+import java.sql.Timestamp
+import java.text.SimpleDateFormat
+
 import static wooga.gradle.version.internal.release.semver.StrategyUtil.*
 
 import java.util.regex.Pattern
@@ -202,6 +205,27 @@ final class Strategies {
          * Sets the pre-release component to the value of {@link SemVerStrategyState#stageFromProp}.
          */
         static final PartialSemVerStrategy STAGE_FIXED = closure { state -> state.copyWith(inferredPreRelease: state.stageFromProp) }
+
+        /**
+         * Sets the pre-release component to the value of {@link SemVerStrategyState#stageFromProp}.
+         */
+        static final PartialSemVerStrategy STAGE_TIMESTAMP = closure { state ->
+            state.copyWith(inferredPreRelease: "${GenerateTimestamp()}")
+        }
+
+        /**
+         * The format of the generated timestamp
+         */
+        static final SimpleDateFormat timestampFormat = new SimpleDateFormat("yyyyMMddHHmm")
+
+        /**
+         * @return Generates a timestamp to be used for versioning
+         */
+        static String GenerateTimestamp() {
+            def timestamp = new Timestamp(System.currentTimeMillis())
+            def result = timestampFormat.format(timestamp)
+            result
+        }
 
         /**
          * If the value of {@link SemVerStrategyState#stageFromProp} has a higher or the same precedence than

--- a/src/main/groovy/wooga/gradle/version/strategies/SemverV1Strategies.groovy
+++ b/src/main/groovy/wooga/gradle/version/strategies/SemverV1Strategies.groovy
@@ -29,7 +29,7 @@ import static wooga.gradle.version.internal.release.semver.StrategyUtil.closure
 import static wooga.gradle.version.internal.release.semver.StrategyUtil.parseIntOrZero
 
 class SemverV1Strategies {
-    private static final scopes = StrategyUtil.one(
+    static final scopes = StrategyUtil.one(
             Strategies.Normal.USE_SCOPE_PROP,
             Strategies.Normal.ENFORCE_GITFLOW_BRANCH_MAJOR_X,
             Strategies.Normal.ENFORCE_BRANCH_MAJOR_X,
@@ -186,13 +186,13 @@ class SemverV1Strategies {
             preReleaseStrategy: StrategyUtil.all(StrategyUtil.closure({state ->
 
                 String branchName = state.currentBranch.name
-                String prefix = "branch"
 
                 if( branchName == "HEAD" && System.getenv("BRANCH_NAME") ) {
                     branchName = System.getenv("BRANCH_NAME")
                 }
 
                 if( branchName != "master") {
+                    String prefix = "branch"
                     branchName = "$prefix${branchName.capitalize()}"
                 }
 

--- a/src/main/groovy/wooga/gradle/version/strategies/WdkStrategies.groovy
+++ b/src/main/groovy/wooga/gradle/version/strategies/WdkStrategies.groovy
@@ -1,0 +1,23 @@
+package wooga.gradle.version.strategies
+
+import wooga.gradle.version.ReleaseStage
+import wooga.gradle.version.internal.release.opinion.Strategies
+import wooga.gradle.version.internal.release.semver.SemVerStrategy
+import wooga.gradle.version.internal.release.semver.StrategyUtil
+
+class WdkStrategies {
+    static final SemVerStrategy DEVELOPMENT = SemverV1Strategies.DEVELOPMENT
+    static final SemVerStrategy SNAPSHOT = SemverV1Strategies.SNAPSHOT
+    static final SemVerStrategy PRE = SemverV1Strategies.SNAPSHOT.copyWith(
+        releaseStage: ReleaseStage.Preflight,
+        // TODO: Must start Between m-r
+        stages: ['pre'] as SortedSet,
+        preReleaseStrategy: StrategyUtil.all(StrategyUtil.closure({ state ->
+            def stage = Strategies.PreRelease.STAGE_FIXED.infer(state).inferredPreRelease
+            def integration = Strategies.PreRelease.STAGE_TIMESTAMP.infer(state).inferredPreRelease
+            state.copyWith(inferredPreRelease: "$stage$integration")
+        })),
+    )
+    static final SemVerStrategy PRE_RELEASE = SemverV1Strategies.PRE_RELEASE
+    static final SemVerStrategy FINAL = SemverV1Strategies.FINAL
+}

--- a/src/test/groovy/wooga/gradle/version/VersionPluginSpec.groovy
+++ b/src/test/groovy/wooga/gradle/version/VersionPluginSpec.groovy
@@ -23,6 +23,7 @@ import org.gradle.cache.internal.VersionStrategy
 import spock.lang.Ignore
 import spock.lang.Unroll
 import wooga.gradle.version.internal.ToStringProvider
+import wooga.gradle.version.internal.release.opinion.Strategies
 
 class VersionPluginSpec extends ProjectSpec {
 
@@ -266,6 +267,155 @@ class VersionPluginSpec extends ProjectSpec {
 
         _               | 1        | "final"    | _       | "1.x"           | "1.0.1"
         _               | 3        | "final"    | _       | "1.0.x"         | "1.0.1"
+
+        nearestNormal = '1.0.0'
+        nearestAnyTitle = (nearestAny == _) ? "unset" : nearestAny
+        scopeTitle = (scope == _) ? "unset" : scope
+    }
+
+    @Unroll('verify inferred wdk version from stage: #stage, nearestNormal: #nearestNormal, nearestAny: #nearestAnyTitle, scope: #scopeTitle,  branch: #branchName to be #expectedVersion')
+    def "uses custom wdk strategies"() {
+
+        given: "a project with specified release stage and scope"
+
+        project.ext.set('version.scheme', 'wdk')
+        project.ext.set('release.stage', stage)
+        if (scope != _) {
+            project.ext.set('release.scope', scope)
+        }
+
+        and: "a history"
+
+        if (branchName != "master") {
+            git.checkout(branch: "$branchName", startPoint: 'master', createBranch: true)
+        }
+
+        5.times {
+            git.commit(message: 'feature commit')
+        }
+
+        // . . . . .
+        // . . . . .* . . .*
+        //      (1.0.0)   (1.0.1-pre00003)
+
+        // . . . . .* . . .* . . .*
+        //      (1.0.0)    (1.0.1-rc00001)  (1.0.1-pre00003)
+
+        git.tag.add(name: "v$nearestNormal")
+
+        distance.times {
+            git.commit(message: 'fix commit')
+        }
+
+        if (nearestAny != _) {
+            git.tag.add(name: "v$nearestAny")
+            distance.times {
+                git.commit(message: 'fix commit')
+            }
+        }
+
+        if (expectedVersion.contains("#TIMESTAMP")) {
+            expectedVersion = expectedVersion.replace("#TIMESTAMP", Strategies.PreRelease.GenerateTimestamp())
+        }
+
+        when:
+        project.plugins.apply(PLUGIN_NAME)
+
+        then:
+        project.version.toString() == expectedVersion
+
+        where:
+        nearestAny       | distance | stage      | scope   | branchName      | expectedVersion
+        _ | 1 | "snapshot" | _       | "master"        | "1.0.1-master00001"
+        _ | 2 | "snapshot" | "major" | "master"        | "2.0.0-master00002"
+        _ | 3 | "snapshot" | "minor" | "master"        | "1.1.0-master00003"
+        _ | 4 | "snapshot" | "patch" | "master"        | "1.0.1-master00004"
+
+        _ | 1 | "snapshot" | _       | "develop"       | "1.0.1-branchDevelop00001"
+        _ | 2 | "snapshot" | "major" | "develop"       | "2.0.0-branchDevelop00002"
+        _ | 3 | "snapshot" | "minor" | "develop"       | "1.1.0-branchDevelop00003"
+        _ | 4 | "snapshot" | "patch" | "develop"       | "1.0.1-branchDevelop00004"
+
+        _ | 1 | "snapshot" | _       | "feature/check" | "1.0.1-branchFeatureCheck00001"
+        _ | 2 | "snapshot" | _       | "hotfix/check"  | "1.0.1-branchHotfixCheck00002"
+        _ | 3 | "snapshot" | _       | "fix/check"     | "1.0.1-branchFixCheck00003"
+        _ | 4 | "snapshot" | _       | "feature-check" | "1.0.1-branchFeatureCheck00004"
+        _ | 5 | "snapshot" | _       | "hotfix-check"  | "1.0.1-branchHotfixCheck00005"
+        _ | 6 | "snapshot" | _       | "fix-check"     | "1.0.1-branchFixCheck00006"
+        _ | 7 | "snapshot" | _       | "PR-22"         | "1.0.1-branchPRTwoTwo00007"
+
+        _ | 1 | "snapshot" | _       | "release/1.x"   | "1.0.1-branchReleaseOneDotx00001"
+        _ | 2 | "snapshot" | _       | "release-1.x"   | "1.0.1-branchReleaseOneDotx00002"
+        _ | 3 | "snapshot" | _       | "release/1.0.x" | "1.0.1-branchReleaseOneDotZeroDotx00003"
+        _ | 4 | "snapshot" | _       | "release-1.0.x" | "1.0.1-branchReleaseOneDotZeroDotx00004"
+
+        _ | 2 | "snapshot" | _       | "1.x"           | "1.0.1-branchOneDotx00002"
+        _ | 4 | "snapshot" | _       | "1.0.x"         | "1.0.1-branchOneDotZeroDotx00004"
+
+        // Pre uses timestamp
+        _                | 1        | "pre"      | _       | "master"        | "1.0.1-pre#TIMESTAMP"
+        _                | 2        | "pre"      | "major" | "master"        | "2.0.0-pre#TIMESTAMP"
+        _                | 3        | "pre"      | "minor" | "master"        | "1.1.0-pre#TIMESTAMP"
+        _                | 4        | "pre"      | "patch" | "master"        | "1.0.1-pre#TIMESTAMP"
+
+        '1.1.0-pre00001' | 1        | "pre"      | _       | "master"        | "1.1.0-pre#TIMESTAMP"
+        '1.1.0-pre00002' | 1        | "pre"      | _       | "master"        | "1.1.0-pre#TIMESTAMP"
+
+        _                | 1        | "pre"      | _       | "release/1.x"   | "1.0.1-pre#TIMESTAMP"
+        _                | 2        | "pre"      | _       | "release-1.x"   | "1.0.1-pre#TIMESTAMP"
+        _                | 3        | "pre"      | _       | "release/1.0.x" | "1.0.1-pre#TIMESTAMP"
+        _                | 4        | "pre"      | _       | "release-1.0.x" | "1.0.1-pre#TIMESTAMP"
+
+        _                | 1        | "pre"      | _       | "1.x"           | "1.0.1-pre#TIMESTAMP"
+        _                | 3        | "pre"      | _       | "1.0.x"         | "1.0.1-pre#TIMESTAMP"
+
+        "1.1.0-pre00001" | 1        | "pre"      | _       | "release/1.x"   | "1.1.0-pre#TIMESTAMP"
+        "1.1.0-pre00001" | 2        | "pre"      | _       | "release-1.x"   | "1.1.0-pre#TIMESTAMP"
+        "1.0.1-pre00001" | 3        | "pre"      | _       | "release/1.0.x" | "1.0.1-pre#TIMESTAMP"
+        "1.0.1-pre00001" | 4        | "pre"      | _       | "release-1.0.x" | "1.0.1-pre#TIMESTAMP"
+
+        "1.1.0-pre00001" | 1        | "pre"      | _       | "1.x"           | "1.1.0-pre#TIMESTAMP"
+        "1.0.1-pre00001" | 3        | "pre"      | _       | "1.0.x"         | "1.0.1-pre#TIMESTAMP"
+
+        _                | 4        | "pre"      | _       | "1.0.x"         | "1.0.1-pre#TIMESTAMP"
+
+        _                | 1        | "rc"       | _       | "master"        | "1.0.1-rc00001"
+        _                | 2        | "rc"       | "major" | "master"        | "2.0.0-rc00001"
+        _                | 3        | "rc"       | "minor" | "master"        | "1.1.0-rc00001"
+        _                | 4        | "rc"       | "patch" | "master"        | "1.0.1-rc00001"
+
+        '1.1.0-rc00001'  | 1        | "rc"       | _       | "master"        | "1.1.0-rc00002"
+        '1.1.0-rc00002'  | 1        | "rc"       | _       | "master"        | "1.1.0-rc00003"
+
+        _                | 1        | "rc"       | _       | "release/1.x"   | "1.0.1-rc00001"
+        _                | 2        | "rc"       | _       | "release-1.x"   | "1.0.1-rc00001"
+        _                | 3        | "rc"       | _       | "release/1.0.x" | "1.0.1-rc00001"
+        _                | 4        | "rc"       | _       | "release-1.0.x" | "1.0.1-rc00001"
+
+        _                | 1        | "rc"       | _       | "1.x"           | "1.0.1-rc00001"
+        _                | 3        | "rc"       | _       | "1.0.x"         | "1.0.1-rc00001"
+
+        "1.1.0-rc00001"  | 1        | "rc"       | _       | "release/1.x"   | "1.1.0-rc00002"
+        "1.1.0-rc00001"  | 2        | "rc"       | _       | "release-1.x"   | "1.1.0-rc00002"
+        "1.0.1-rc00001"  | 3        | "rc"       | _       | "release/1.0.x" | "1.0.1-rc00002"
+        "1.0.1-rc00001"  | 4        | "rc"       | _       | "release-1.0.x" | "1.0.1-rc00002"
+
+        "1.1.0-rc00001"  | 1        | "rc"       | _       | "1.x"           | "1.1.0-rc00002"
+        "1.0.1-rc00001"  | 3        | "rc"       | _       | "1.0.x"         | "1.0.1-rc00002"
+
+        _                | 1        | "final"    | _       | "master"        | "1.0.1"
+        _                | 2        | "final"    | "major" | "master"        | "2.0.0"
+        _                | 3        | "final"    | "minor" | "master"        | "1.1.0"
+        _                | 4        | "final"    | "patch" | "master"        | "1.0.1"
+
+        _                | 1        | "final"    | _       | "release/1.x"   | "1.0.1"
+        _                | 1        | "final"    | _       | "release/1.x"   | "1.0.1"
+        _                | 2        | "final"    | _       | "release-1.x"   | "1.0.1"
+        _                | 3        | "final"    | _       | "release/1.0.x" | "1.0.1"
+        _                | 4        | "final"    | _       | "release-1.0.x" | "1.0.1"
+
+        _                | 1        | "final"    | _       | "1.x"           | "1.0.1"
+        _                | 3        | "final"    | _       | "1.0.x"         | "1.0.1"
 
         nearestNormal = '1.0.0'
         nearestAnyTitle = (nearestAny == _) ? "unset" : nearestAny


### PR DESCRIPTION
## Description

Adds a custom "preflight" stage to be used mainly for integration testing before a more format pre-release.

## Changes
* ![ADD] Add a custom wdk strategy, which contains the newer preflight stage
* ![ADD] Add some helpers to generate the preflight release

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"
