### PR TITLE
Map enum value `semver1` to `semver`

### DIFF
--- a/src/main/groovy/wooga/gradle/version/VersionPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/version/VersionPlugin.groovy
@@ -74,8 +74,13 @@ class VersionPlugin implements Plugin<Project> {
         def extension = project.extensions.create(VersionPluginExtension, EXTENSION_NAME, DefaultVersionPluginExtension, project)
 
         extension.versionScheme.set(VersionPluginConventions.versionScheme.getStringValueProvider(project).map({
-            VersionScheme.valueOf(it.trim())
-            }))
+            def value = it.trim()
+            // Special fallback due to legacy reasons
+            if (value == "semver1"){
+                value = "semver"
+            }
+            VersionScheme.valueOf(value)
+        }))
 
         extension.versionCodeScheme.set(VersionPluginConventions.versionCodeScheme.getStringValueProvider(project).map({
             VersionCodeScheme.valueOf(it.trim())

--- a/src/test/groovy/wooga/gradle/version/VersionPluginSpec.groovy
+++ b/src/test/groovy/wooga/gradle/version/VersionPluginSpec.groovy
@@ -79,6 +79,28 @@ class VersionPluginSpec extends ProjectSpec {
         'versionBuilder' | VersionPluginExtension
     }
 
+    // This is done due to legacy reasons
+    @Unroll
+    def "Maps version scheme `#from` to `#expected`"() {
+        given:
+        assert !project.plugins.hasPlugin(PLUGIN_NAME)
+
+        and:
+        project.extensions[propertyName] = from
+
+        when:
+        project.plugins.apply(PLUGIN_NAME)
+
+        then:
+        def extension = project.extensions.getByType(VersionPluginExtension)
+        extension.versionScheme.get() == expected
+
+        where:
+        propertyName     | from      | expected
+        "version.scheme" | "semver"  | VersionScheme.semver
+        "version.scheme" | "semver1" | VersionScheme.semver
+    }
+
     @Unroll
     def 'Creates the [#extensionName] extension with type #extensionType when no git repo is in project'() {
         given:


### PR DESCRIPTION
## Description

Fixes an issue downstream where projects reference `semver1`, which is not a valid `VersionScheme` enum value. It will now be mapped to `semver`, which was the intent.

## Changes
* ![UPDATE]  Add mapping from `semver1` to `semver`

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:https://atlas-resources.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:https://atlas-resources.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:https://atlas-resources.wooga.com/icons/icon_change.svg "Change"
[FIX]:https://atlas-resources.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:https://atlas-resources.wooga.com/icons/icon_update.svg "Update"

[BREAK]:https://atlas-resources.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:https://atlas-resources.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:https://atlas-resources.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:https://atlas-resources.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:https://atlas-resources.wooga.com/icons/icon_webGL.svg "Web:GL"
[GRADLE]:https://atlas-resources.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:https://atlas-resources.wooga.com/icons/icon_unity.svg "Unity"
