### PR TITLE
Previous version property is null when there isn't any version tag on git

### DIFF
--- a/src/main/groovy/wooga/gradle/version/internal/release/semver/NearestVersion.groovy
+++ b/src/main/groovy/wooga/gradle/version/internal/release/semver/NearestVersion.groovy
@@ -26,6 +26,8 @@ import com.github.zafarkhaja.semver.Version
  */
 @Immutable(knownImmutableClasses=[Version])
 class NearestVersion {
+    static final Version EMPTY = Version.valueOf('0.0.0')
+
     /**
      * The nearest version that is tagged.
      */

--- a/src/main/groovy/wooga/gradle/version/internal/release/semver/NearestVersionLocator.groovy
+++ b/src/main/groovy/wooga/gradle/version/internal/release/semver/NearestVersionLocator.groovy
@@ -15,7 +15,6 @@
  */
 package wooga.gradle.version.internal.release.semver
 
-import com.github.zafarkhaja.semver.Version
 import wooga.gradle.version.internal.release.base.TagStrategy
 import org.ajoberstar.grgit.Grgit
 import org.eclipse.jgit.lib.ObjectId
@@ -40,7 +39,6 @@ import org.slf4j.LoggerFactory
  */
 class NearestVersionLocator {
     private static final Logger logger = LoggerFactory.getLogger(NearestVersionLocator)
-    private static final Version UNKNOWN = Version.valueOf('0.0.0')
 
     final TagStrategy strategy
 
@@ -107,7 +105,7 @@ class NearestVersionLocator {
             def any = findNearestVersion(walk, head, tags)
 
             logger.debug('Nearest release: {}, nearest any: {}.', normal, any)
-            return new NearestVersion(any.version, normal.version, any.distance, normal.distance)
+            return new NearestVersion([any: any.version, normal: normal.version, distanceFromAny: any.distance, distanceFromNormal: normal.distance])
         } finally {
             walk.close()
         }
@@ -136,7 +134,7 @@ class NearestVersionLocator {
                 distanceCompare == 0 ? versionCompare : distanceCompare
             }
         } else {
-            return [version: UNKNOWN, distance: RevWalkUtils.count(walk, head, null)]
+            return [version: NearestVersion.EMPTY, distance: RevWalkUtils.count(walk, head, null)]
         }
     }
 }

--- a/src/main/groovy/wooga/gradle/version/internal/release/semver/SemVerStrategy.groovy
+++ b/src/main/groovy/wooga/gradle/version/internal/release/semver/SemVerStrategy.groovy
@@ -187,11 +187,7 @@ final class SemVerStrategy implements DefaultVersionStrategy {
         if (enforcePrecedence && version < nearestVersion.any) {
             throw new GradleException("Inferred version (${version}) cannot be lower than nearest (${nearestVersion.any}). Required by selected strategy.")
         }
-
-        return new ReleaseVersion(version.toString(), nearestVersion.normal.toString(), createTag)
-    }
-
-    private String getPropertyOrNull(Project project, String name) {
-        return project.hasProperty(name) ? project.property(name) : null
+        def nearestNormal = nearestVersion.normal == NearestVersion.EMPTY? null: nearestVersion.normal
+        return new ReleaseVersion(version.toString(), nearestNormal?.toString(), createTag)
     }
 }

--- a/src/test/groovy/wooga/gradle/version/VersionPluginSpec.groovy
+++ b/src/test/groovy/wooga/gradle/version/VersionPluginSpec.groovy
@@ -39,7 +39,7 @@ class VersionPluginSpec extends ProjectSpec {
         git = Grgit.init(dir: projectDir)
         git.add(patterns: ['.gitignore'])
         git.commit(message: 'initial commit')
-        git.tag.add(name: 'v0.0.1')
+//        git.tag.add(name: 'v0.0.1')
     }
 
     @Ignore
@@ -110,14 +110,12 @@ class VersionPluginSpec extends ProjectSpec {
     def "uses custom wooga semver strategies"() {
 
         given: "a project with specified release stage and scope"
-
         project.ext.set('release.stage', stage)
         if (scope) {
             project.ext.set('release.scope', scope)
         }
 
         and: "a history"
-
         if (branchName != "master") {
             git.checkout(branch: "$branchName", startPoint: 'master', createBranch: true)
         }
@@ -125,8 +123,9 @@ class VersionPluginSpec extends ProjectSpec {
         commitsBefore.times {
             git.commit(message: 'feature commit')
         }
-
-        git.tag.add(name: "v$tagVersion")
+        if (tagVersion != null) {
+            git.tag.add(name: "v$tagVersion")
+        }
 
         commitsAfter.times {
             git.commit(message: 'fix commit')
@@ -141,6 +140,11 @@ class VersionPluginSpec extends ProjectSpec {
         where:
 
         tagVersion      | commitsBefore | commitsAfter | stage      | scope   | branchName      | expectedVersion
+        null            | 1             | 0            | "SNAPSHOT" | "minor" | "master"        | "0.1.0-master00002"
+        null            | 1             | 0            | "rc"       | "minor" | "master"        | "0.1.0-rc00001"
+        null            | 1             | 0            | "final"    | "minor" | "master"        | "0.1.0"
+        null            | 1             | 0            | "final"    | "major" | "master"        | "1.0.0"
+        null            | 1             | 0            | "final"    | "patch" | "master"        | "0.0.1"
         '1.0.0'         | 1             | 3            | "SNAPSHOT" | "minor" | "master"        | "1.1.0-master00003"
         '1.0.0'         | 1             | 3            | "rc"       | "minor" | "master"        | "1.1.0-rc00001"
         '1.0.0'         | 1             | 3            | "final"    | "minor" | "master"        | "1.1.0"
@@ -440,16 +444,16 @@ class VersionPluginSpec extends ProjectSpec {
             git.checkout(branch: "$branchName", startPoint: 'master', createBranch: true)
         }
 
-        5.times {
-            git.commit(message: 'feature commit')
+        if (nearestNormal != _) {
+            5.times {
+                git.commit(message: 'feature commit')
+            }
+            git.tag.add(name: "v$nearestNormal")
+
         }
-
-        git.tag.add(name: "v$nearestNormal")
-
         distance.times {
             git.commit(message: 'fix commit')
         }
-
         if (nearestAny != _) {
             git.tag.add(name: "v$nearestAny")
             distance.times {
@@ -467,38 +471,61 @@ class VersionPluginSpec extends ProjectSpec {
         project.versionCode.toString() == expectedVersionCode.toString()
 
         where:
-        nearestAny        | distance | stage      | scope   | branchName | versionCodeScheme             | expectedVersion   | expectedVersionCode
-        _                 | 1        | "snapshot" | _       | "master"   | VersionCodeScheme.semver      | "1.1.0-master.1"  | 101000
-        _                 | 2        | "snapshot" | "major" | "master"   | VersionCodeScheme.semver      | "2.0.0-master.2"  | 200000
-        _                 | 3        | "snapshot" | "minor" | "master"   | VersionCodeScheme.semver      | "1.1.0-master.3"  | 101000
-        _                 | 4        | "snapshot" | "patch" | "master"   | VersionCodeScheme.semver      | "1.0.1-master.4"  | 100010
-        _                 | 1        | "snapshot" | _       | "develop"  | VersionCodeScheme.semver      | "1.1.0-develop.1" | 101000
-        _                 | 2        | "snapshot" | "major" | "develop"  | VersionCodeScheme.semver      | "2.0.0-develop.2" | 200000
-        _                 | 3        | "snapshot" | "minor" | "develop"  | VersionCodeScheme.semver      | "1.1.0-develop.3" | 101000
-        _                 | 4        | "snapshot" | "patch" | "develop"  | VersionCodeScheme.semver      | "1.0.1-develop.4" | 100010
-        _                 | 1        | "rc"       | _       | "master"   | VersionCodeScheme.semver      | "1.1.0-rc.1"      | 101000
-        _                 | 2        | "rc"       | "major" | "master"   | VersionCodeScheme.semver      | "2.0.0-rc.1"      | 200000
-        _                 | 3        | "rc"       | "minor" | "master"   | VersionCodeScheme.semver      | "1.1.0-rc.1"      | 101000
-        _                 | 4        | "rc"       | "patch" | "master"   | VersionCodeScheme.semver      | "1.0.1-rc.1"      | 100010
-        '1.1.0-staging.1' | 1        | "staging"  | _       | "master"   | VersionCodeScheme.semver      | "1.1.0-staging.2" | 101002
-        '1.1.0-staging.2' | 1        | "staging"  | _       | "master"   | VersionCodeScheme.semver      | "1.1.0-staging.3" | 101003
+        nearestNormal | nearestAny        | distance | stage      | scope   | branchName | versionCodeScheme             | expectedVersion   | expectedVersionCode
+        _             | _                 | 1        | "snapshot" | _       | "master"   | VersionCodeScheme.semver      | "0.1.0-master.2"  | 1000
+        _             | _                 | 2        | "snapshot" | "major" | "master"   | VersionCodeScheme.semver      | "1.0.0-master.3"  | 100000
+        _             | _                 | 3        | "snapshot" | "minor" | "master"   | VersionCodeScheme.semver      | "0.1.0-master.4"  | 1000
+        _             | _                 | 4        | "snapshot" | "patch" | "master"   | VersionCodeScheme.semver      | "0.0.1-master.5"  | 10
+        '1.0.0'       | _                 | 1        | "snapshot" | _       | "master"   | VersionCodeScheme.semver      | "1.1.0-master.1"  | 101000
+        '1.0.0'       | _                 | 2        | "snapshot" | "major" | "master"   | VersionCodeScheme.semver      | "2.0.0-master.2"  | 200000
+        '1.0.0'       | _                 | 3        | "snapshot" | "minor" | "master"   | VersionCodeScheme.semver      | "1.1.0-master.3"  | 101000
+        '1.0.0'       | _                 | 4        | "snapshot" | "patch" | "master"   | VersionCodeScheme.semver      | "1.0.1-master.4"  | 100010
+        '1.0.0'       | _                 | 1        | "snapshot" | _       | "develop"  | VersionCodeScheme.semver      | "1.1.0-develop.1" | 101000
+        '1.0.0'       | _                 | 2        | "snapshot" | "major" | "develop"  | VersionCodeScheme.semver      | "2.0.0-develop.2" | 200000
+        '1.0.0'       | _                 | 3        | "snapshot" | "minor" | "develop"  | VersionCodeScheme.semver      | "1.1.0-develop.3" | 101000
+        '1.0.0'       | _                 | 4        | "snapshot" | "patch" | "develop"  | VersionCodeScheme.semver      | "1.0.1-develop.4" | 100010
 
-        _                 | 1        | "snapshot" | _       | "master"   | VersionCodeScheme.semverBasic | "1.1.0-master.1"  | 10100
-        _                 | 2        | "snapshot" | "major" | "master"   | VersionCodeScheme.semverBasic | "2.0.0-master.2"  | 20000
-        _                 | 3        | "snapshot" | "minor" | "master"   | VersionCodeScheme.semverBasic | "1.1.0-master.3"  | 10100
-        _                 | 4        | "snapshot" | "patch" | "master"   | VersionCodeScheme.semverBasic | "1.0.1-master.4"  | 10001
-        _                 | 1        | "snapshot" | _       | "develop"  | VersionCodeScheme.semverBasic | "1.1.0-develop.1" | 10100
-        _                 | 2        | "snapshot" | "major" | "develop"  | VersionCodeScheme.semverBasic | "2.0.0-develop.2" | 20000
-        _                 | 3        | "snapshot" | "minor" | "develop"  | VersionCodeScheme.semverBasic | "1.1.0-develop.3" | 10100
-        _                 | 4        | "snapshot" | "patch" | "develop"  | VersionCodeScheme.semverBasic | "1.0.1-develop.4" | 10001
-        _                 | 1        | "rc"       | _       | "master"   | VersionCodeScheme.semverBasic | "1.1.0-rc.1"      | 10100
-        _                 | 2        | "rc"       | "major" | "master"   | VersionCodeScheme.semverBasic | "2.0.0-rc.1"      | 20000
-        _                 | 3        | "rc"       | "minor" | "master"   | VersionCodeScheme.semverBasic | "1.1.0-rc.1"      | 10100
-        _                 | 4        | "rc"       | "patch" | "master"   | VersionCodeScheme.semverBasic | "1.0.1-rc.1"      | 10001
-        '1.1.0-staging.1' | 1        | "staging"  | _       | "master"   | VersionCodeScheme.semverBasic | "1.1.0-staging.2" | 10100
-        '1.1.0-staging.2' | 1        | "staging"  | _       | "master"   | VersionCodeScheme.semverBasic | "1.1.0-staging.3" | 10100
+        _             | _                 | 1        | "rc"       | _       | "master"   | VersionCodeScheme.semver      | "0.1.0-rc.1"      | 1000
+        _             | _                 | 2        | "rc"       | "major" | "master"   | VersionCodeScheme.semver      | "1.0.0-rc.1"      | 100000
+        _             | _                 | 3        | "rc"       | "minor" | "master"   | VersionCodeScheme.semver      | "0.1.0-rc.1"      | 1000
+        _             | _                 | 4        | "rc"       | "patch" | "master"   | VersionCodeScheme.semver      | "0.0.1-rc.1"      | 10
+        '1.0.0'       | _                 | 1        | "rc"       | _       | "master"   | VersionCodeScheme.semver      | "1.1.0-rc.1"      | 101000
+        '1.0.0'       | _                 | 2        | "rc"       | "major" | "master"   | VersionCodeScheme.semver      | "2.0.0-rc.1"      | 200000
+        '1.0.0'       | _                 | 3        | "rc"       | "minor" | "master"   | VersionCodeScheme.semver      | "1.1.0-rc.1"      | 101000
+        '1.0.0'       | _                 | 4        | "rc"       | "patch" | "master"   | VersionCodeScheme.semver      | "1.0.1-rc.1"      | 100010
 
-        nearestNormal = '1.0.0'
+        _             | '1.1.0-staging.1' | 1        | "staging"  | _       | "master"   | VersionCodeScheme.semver      | "1.1.0-staging.2" | 101002
+        _             | '1.1.0-staging.2' | 1        | "staging"  | _       | "master"   | VersionCodeScheme.semver      | "1.1.0-staging.3" | 101003
+        '1.0.0'       | '1.1.0-staging.1' | 1        | "staging"  | _       | "master"   | VersionCodeScheme.semver      | "1.1.0-staging.2" | 101002
+        '1.0.0'       | '1.1.0-staging.2' | 1        | "staging"  | _       | "master"   | VersionCodeScheme.semver      | "1.1.0-staging.3" | 101003
+
+        _             | _                 | 1        | "snapshot" | _       | "master"   | VersionCodeScheme.semverBasic | "0.1.0-master.2"  | 100
+        _             | _                 | 2        | "snapshot" | "major" | "master"   | VersionCodeScheme.semverBasic | "1.0.0-master.3"  | 10000
+        _             | _                 | 3        | "snapshot" | "minor" | "master"   | VersionCodeScheme.semverBasic | "0.1.0-master.4"  | 100
+        _             | _                 | 4        | "snapshot" | "patch" | "master"   | VersionCodeScheme.semverBasic | "0.0.1-master.5"  | 1
+        '1.0.0'       | _                 | 1        | "snapshot" | _       | "master"   | VersionCodeScheme.semverBasic | "1.1.0-master.1"  | 10100
+        '1.0.0'       | _                 | 2        | "snapshot" | "major" | "master"   | VersionCodeScheme.semverBasic | "2.0.0-master.2"  | 20000
+        '1.0.0'       | _                 | 3        | "snapshot" | "minor" | "master"   | VersionCodeScheme.semverBasic | "1.1.0-master.3"  | 10100
+        '1.0.0'       | _                 | 4        | "snapshot" | "patch" | "master"   | VersionCodeScheme.semverBasic | "1.0.1-master.4"  | 10001
+        '1.0.0'       | _                 | 1        | "snapshot" | _       | "develop"  | VersionCodeScheme.semverBasic | "1.1.0-develop.1" | 10100
+        '1.0.0'       | _                 | 2        | "snapshot" | "major" | "develop"  | VersionCodeScheme.semverBasic | "2.0.0-develop.2" | 20000
+        '1.0.0'       | _                 | 3        | "snapshot" | "minor" | "develop"  | VersionCodeScheme.semverBasic | "1.1.0-develop.3" | 10100
+        '1.0.0'       | _                 | 4        | "snapshot" | "patch" | "develop"  | VersionCodeScheme.semverBasic | "1.0.1-develop.4" | 10001
+
+        _             | _                 | 1        | "rc"       | _       | "master"   | VersionCodeScheme.semverBasic | "0.1.0-rc.1"      | 100
+        _             | _                 | 2        | "rc"       | "major" | "master"   | VersionCodeScheme.semverBasic | "1.0.0-rc.1"      | 10000
+        _             | _                 | 3        | "rc"       | "minor" | "master"   | VersionCodeScheme.semverBasic | "0.1.0-rc.1"      | 100
+        _             | _                 | 4        | "rc"       | "patch" | "master"   | VersionCodeScheme.semverBasic | "0.0.1-rc.1"      | 1
+        '1.0.0'       | _                 | 1        | "rc"       | _       | "master"   | VersionCodeScheme.semverBasic | "1.1.0-rc.1"      | 10100
+        '1.0.0'       | _                 | 2        | "rc"       | "major" | "master"   | VersionCodeScheme.semverBasic | "2.0.0-rc.1"      | 20000
+        '1.0.0'       | _                 | 3        | "rc"       | "minor" | "master"   | VersionCodeScheme.semverBasic | "1.1.0-rc.1"      | 10100
+        '1.0.0'       | _                 | 4        | "rc"       | "patch" | "master"   | VersionCodeScheme.semverBasic | "1.0.1-rc.1"      | 10001
+
+        _             | '0.1.0-staging.1' | 1        | "staging"  | _       | "master"   | VersionCodeScheme.semverBasic | "0.1.0-staging.2" | 100
+        _             | '0.1.0-staging.2' | 1        | "staging"  | _       | "master"   | VersionCodeScheme.semverBasic | "0.1.0-staging.3" | 100
+        '1.0.0'       | '1.1.0-staging.1' | 1        | "staging"  | _       | "master"   | VersionCodeScheme.semverBasic | "1.1.0-staging.2" | 10100
+        '1.0.0'       | '1.1.0-staging.2' | 1        | "staging"  | _       | "master"   | VersionCodeScheme.semverBasic | "1.1.0-staging.3" | 10100
+
         nearestAnyTitle = (nearestAny == _) ? "unset" : nearestAny
         scopeTitle = (scope == _) ? "unset" : scope
     }
@@ -541,10 +568,10 @@ class VersionPluginSpec extends ProjectSpec {
 
         where:
         numberOfFinalReleases | numberOfPrereleases | offset | scheme                              | expectedVersionCode
-        5                     | 5                   | 0      | VersionCodeScheme.releaseCountBasic | 6
-        5                     | 5                   | 3      | VersionCodeScheme.releaseCountBasic | 9
-        10                    | 2                   | 0      | VersionCodeScheme.releaseCount      | 13
-        7                     | 0                   | 5      | VersionCodeScheme.releaseCount      | 13
+        5                     | 5                   | 0      | VersionCodeScheme.releaseCountBasic | 5
+        5                     | 5                   | 3      | VersionCodeScheme.releaseCountBasic | 8
+        10                    | 2                   | 0      | VersionCodeScheme.releaseCount      | 12
+        7                     | 0                   | 5      | VersionCodeScheme.releaseCount      | 12
         3                     | 8                   | 5      | VersionCodeScheme.none              | 0
         3                     | 8                   | 5      | _                                   | 0
     }
@@ -581,12 +608,12 @@ class VersionPluginSpec extends ProjectSpec {
         if (branchName != "master") {
             git.checkout(branch: "$branchName", startPoint: 'master', createBranch: true)
         }
-
-        5.times {
-            git.commit(message: 'feature commit')
+        if (nearestNormal != _) {
+            5.times {
+                git.commit(message: 'feature commit')
+            }
+            git.tag.add(name: "v$nearestNormal")
         }
-
-        git.tag.add(name: "v$nearestNormal")
 
         distance.times {
             git.commit(message: 'fix commit')
@@ -606,155 +633,199 @@ class VersionPluginSpec extends ProjectSpec {
         project.version.toString() == expectedVersion
 
         where:
-        nearestAny        | distance | stage        | scope   | branchName                 | expectedVersion
-        _                 | 1        | "ci"         | _       | "master"                   | "1.1.0-master.1"
-        _                 | 2        | "ci"         | "major" | "master"                   | "2.0.0-master.2"
-        _                 | 3        | "ci"         | "minor" | "master"                   | "1.1.0-master.3"
-        _                 | 4        | "ci"         | "patch" | "master"                   | "1.0.1-master.4"
+        nearestNormal | nearestAny        | distance | stage        | scope   | branchName                 | expectedVersion
+        _             | _                 | 1        | "ci"         | _       | "master"                   | "0.1.0-master.2"
+        _             | _                 | 2        | "ci"         | "major" | "master"                   | "1.0.0-master.3"
+        _             | _                 | 3        | "ci"         | "minor" | "master"                   | "0.1.0-master.4"
+        _             | _                 | 4        | "ci"         | "patch" | "master"                   | "0.0.1-master.5"
 
-        _                 | 1        | "ci"         | _       | "develop"                  | "1.1.0-develop.1"
-        _                 | 2        | "ci"         | "major" | "develop"                  | "2.0.0-develop.2"
-        _                 | 3        | "ci"         | "minor" | "develop"                  | "1.1.0-develop.3"
-        _                 | 4        | "ci"         | "patch" | "develop"                  | "1.0.1-develop.4"
+        '1.0.0'       | _                 | 1        | "ci"         | _       | "master"                   | "1.1.0-master.1"
+        '1.0.0'       | _                 | 2        | "ci"         | "major" | "master"                   | "2.0.0-master.2"
+        '1.0.0'       | _                 | 3        | "ci"         | "minor" | "master"                   | "1.1.0-master.3"
+        '1.0.0'       | _                 | 4        | "ci"         | "patch" | "master"                   | "1.0.1-master.4"
 
-        _                 | 1        | "ci"         | _       | "feature/check"            | "1.1.0-branch.feature.check.1"
-        _                 | 2        | "ci"         | _       | "hotfix/check"             | "1.0.1-branch.hotfix.check.2"
-        _                 | 3        | "ci"         | _       | "fix/check"                | "1.1.0-branch.fix.check.3"
-        _                 | 4        | "ci"         | _       | "feature-check"            | "1.1.0-branch.feature.check.4"
-        _                 | 5        | "ci"         | _       | "hotfix-check"             | "1.0.1-branch.hotfix.check.5"
-        _                 | 6        | "ci"         | _       | "fix-check"                | "1.1.0-branch.fix.check.6"
-        _                 | 7        | "ci"         | _       | "PR-22"                    | "1.1.0-branch.pr.22.7"
 
-        _                 | 1        | "ci"         | _       | "release/1.x"              | "1.1.0-branch.release.1.x.1"
-        _                 | 2        | "ci"         | _       | "release-1.x"              | "1.1.0-branch.release.1.x.2"
-        _                 | 3        | "ci"         | _       | "release/1.0.x"            | "1.0.1-branch.release.1.0.x.3"
-        _                 | 4        | "ci"         | _       | "release-1.0.x"            | "1.0.1-branch.release.1.0.x.4"
+        '1.0.0'       | _                 | 1        | "ci"         | _       | "develop"                  | "1.1.0-develop.1"
+        '1.0.0'       | _                 | 2        | "ci"         | "major" | "develop"                  | "2.0.0-develop.2"
+        '1.0.0'       | _                 | 3        | "ci"         | "minor" | "develop"                  | "1.1.0-develop.3"
+        '1.0.0'       | _                 | 4        | "ci"         | "patch" | "develop"                  | "1.0.1-develop.4"
 
-        _                 | 2        | "ci"         | _       | "1.x"                      | "1.1.0-branch.1.x.2"
-        _                 | 4        | "ci"         | _       | "1.0.x"                    | "1.0.1-branch.1.0.x.4"
-        '2.0.0-rc.2'      | 0        | "ci"         | _       | "release/2.x"              | "2.0.0-branch.release.2.x.0"
+        '1.0.0'       | _                 | 1        | "ci"         | _       | "feature/check"            | "1.1.0-branch.feature.check.1"
+        '1.0.0'       | _                 | 2        | "ci"         | _       | "hotfix/check"             | "1.0.1-branch.hotfix.check.2"
+        '1.0.0'       | _                 | 3        | "ci"         | _       | "fix/check"                | "1.1.0-branch.fix.check.3"
+        '1.0.0'       | _                 | 4        | "ci"         | _       | "feature-check"            | "1.1.0-branch.feature.check.4"
+        '1.0.0'       | _                 | 5        | "ci"         | _       | "hotfix-check"             | "1.0.1-branch.hotfix.check.5"
+        '1.0.0'       | _                 | 6        | "ci"         | _       | "fix-check"                | "1.1.0-branch.fix.check.6"
+        '1.0.0'       | _                 | 7        | "ci"         | _       | "PR-22"                    | "1.1.0-branch.pr.22.7"
 
-        _                 | 1        | "snapshot"   | _       | "master"                   | "1.1.0-master.1"
-        _                 | 2        | "snapshot"   | "major" | "master"                   | "2.0.0-master.2"
-        _                 | 3        | "snapshot"   | "minor" | "master"                   | "1.1.0-master.3"
-        _                 | 4        | "snapshot"   | "patch" | "master"                   | "1.0.1-master.4"
+        '1.0.0'       | _                 | 1        | "ci"         | _       | "release/1.x"              | "1.1.0-branch.release.1.x.1"
+        '1.0.0'       | _                 | 2        | "ci"         | _       | "release-1.x"              | "1.1.0-branch.release.1.x.2"
+        '1.0.0'       | _                 | 3        | "ci"         | _       | "release/1.0.x"            | "1.0.1-branch.release.1.0.x.3"
+        '1.0.0'       | _                 | 4        | "ci"         | _       | "release-1.0.x"            | "1.0.1-branch.release.1.0.x.4"
 
-        _                 | 1        | "snapshot"   | _       | "develop"                  | "1.1.0-develop.1"
-        _                 | 2        | "snapshot"   | "major" | "develop"                  | "2.0.0-develop.2"
-        _                 | 3        | "snapshot"   | "minor" | "develop"                  | "1.1.0-develop.3"
-        _                 | 4        | "snapshot"   | "patch" | "develop"                  | "1.0.1-develop.4"
+        '1.0.0'       | _                 | 2        | "ci"         | _       | "1.x"                      | "1.1.0-branch.1.x.2"
+        '1.0.0'       | _                 | 4        | "ci"         | _       | "1.0.x"                    | "1.0.1-branch.1.0.x.4"
 
-        _                 | 1        | "snapshot"   | _       | "feature/check"            | "1.1.0-branch.feature.check.1"
-        _                 | 2        | "snapshot"   | _       | "hotfix/check"             | "1.0.1-branch.hotfix.check.2"
-        _                 | 3        | "snapshot"   | _       | "fix/check"                | "1.1.0-branch.fix.check.3"
-        _                 | 4        | "snapshot"   | _       | "feature-check"            | "1.1.0-branch.feature.check.4"
-        _                 | 5        | "snapshot"   | _       | "hotfix-check"             | "1.0.1-branch.hotfix.check.5"
-        _                 | 6        | "snapshot"   | _       | "fix-check"                | "1.1.0-branch.fix.check.6"
-        _                 | 7        | "snapshot"   | _       | "PR-22"                    | "1.1.0-branch.pr.22.7"
+        '1.0.0'       | '2.0.0-rc.2'      | 0        | "ci"         | _       | "release/2.x"              | "2.0.0-branch.release.2.x.0"
 
-        _                 | 1        | "snapshot"   | _       | "release/1.x"              | "1.1.0-branch.release.1.x.1"
-        _                 | 2        | "snapshot"   | _       | "release-1.x"              | "1.1.0-branch.release.1.x.2"
-        _                 | 3        | "snapshot"   | _       | "release/1.0.x"            | "1.0.1-branch.release.1.0.x.3"
-        _                 | 4        | "snapshot"   | _       | "release-1.0.x"            | "1.0.1-branch.release.1.0.x.4"
+        _             | _                 | 1        | "snapshot"   | _       | "master"                   | "0.1.0-master.2"
+        _             | _                 | 2        | "snapshot"   | "major" | "master"                   | "1.0.0-master.3"
+        _             | _                 | 3        | "snapshot"   | "minor" | "master"                   | "0.1.0-master.4"
+        _             | _                 | 4        | "snapshot"   | "patch" | "master"                   | "0.0.1-master.5"
 
-        _                 | 2        | "snapshot"   | _       | "1.x"                      | "1.1.0-branch.1.x.2"
-        _                 | 4        | "snapshot"   | _       | "1.0.x"                    | "1.0.1-branch.1.0.x.4"
+        '1.0.0'       | _                 | 1        | "snapshot"   | _       | "master"                   | "1.1.0-master.1"
+        '1.0.0'       | _                 | 2        | "snapshot"   | "major" | "master"                   | "2.0.0-master.2"
+        '1.0.0'       | _                 | 3        | "snapshot"   | "minor" | "master"                   | "1.1.0-master.3"
+        '1.0.0'       | _                 | 4        | "snapshot"   | "patch" | "master"                   | "1.0.1-master.4"
 
-        _                 | 1        | "staging"    | _       | "master"                   | "1.1.0-staging.1"
-        _                 | 2        | "staging"    | "major" | "master"                   | "2.0.0-staging.1"
-        _                 | 3        | "staging"    | "minor" | "master"                   | "1.1.0-staging.1"
-        _                 | 4        | "staging"    | "patch" | "master"                   | "1.0.1-staging.1"
+        '1.0.0'       | _                 | 1        | "snapshot"   | _       | "develop"                  | "1.1.0-develop.1"
+        '1.0.0'       | _                 | 2        | "snapshot"   | "major" | "develop"                  | "2.0.0-develop.2"
+        '1.0.0'       | _                 | 3        | "snapshot"   | "minor" | "develop"                  | "1.1.0-develop.3"
+        '1.0.0'       | _                 | 4        | "snapshot"   | "patch" | "develop"                  | "1.0.1-develop.4"
 
-        '1.1.0-staging.1' | 1        | "staging"    | _       | "master"                   | "1.1.0-staging.2"
-        '1.1.0-staging.2' | 1        | "staging"    | _       | "master"                   | "1.1.0-staging.3"
+        '1.0.0'       | _                 | 1        | "snapshot"   | _       | "feature/check"            | "1.1.0-branch.feature.check.1"
+        '1.0.0'       | _                 | 2        | "snapshot"   | _       | "hotfix/check"             | "1.0.1-branch.hotfix.check.2"
+        '1.0.0'       | _                 | 3        | "snapshot"   | _       | "fix/check"                | "1.1.0-branch.fix.check.3"
+        '1.0.0'       | _                 | 4        | "snapshot"   | _       | "feature-check"            | "1.1.0-branch.feature.check.4"
+        '1.0.0'       | _                 | 5        | "snapshot"   | _       | "hotfix-check"             | "1.0.1-branch.hotfix.check.5"
+        '1.0.0'       | _                 | 6        | "snapshot"   | _       | "fix-check"                | "1.1.0-branch.fix.check.6"
+        '1.0.0'       | _                 | 7        | "snapshot"   | _       | "PR-22"                    | "1.1.0-branch.pr.22.7"
 
-        _                 | 1        | "staging"    | _       | "release/1.x"              | "1.1.0-staging.1"
-        _                 | 2        | "staging"    | _       | "release-1.x"              | "1.1.0-staging.1"
-        _                 | 3        | "staging"    | _       | "release/1.0.x"            | "1.0.1-staging.1"
-        _                 | 4        | "staging"    | _       | "release-1.0.x"            | "1.0.1-staging.1"
+        '1.0.0'       | _                 | 1        | "snapshot"   | _       | "release/1.x"              | "1.1.0-branch.release.1.x.1"
+        '1.0.0'       | _                 | 2        | "snapshot"   | _       | "release-1.x"              | "1.1.0-branch.release.1.x.2"
+        '1.0.0'       | _                 | 3        | "snapshot"   | _       | "release/1.0.x"            | "1.0.1-branch.release.1.0.x.3"
+        '1.0.0'       | _                 | 4        | "snapshot"   | _       | "release-1.0.x"            | "1.0.1-branch.release.1.0.x.4"
 
-        _                 | 1        | "staging"    | _       | "1.x"                      | "1.1.0-staging.1"
-        _                 | 3        | "staging"    | _       | "1.0.x"                    | "1.0.1-staging.1"
+        '1.0.0'       | _                 | 2        | "snapshot"   | _       | "1.x"                      | "1.1.0-branch.1.x.2"
+        '1.0.0'       | _                 | 4        | "snapshot"   | _       | "1.0.x"                    | "1.0.1-branch.1.0.x.4"
 
-        "1.1.0-staging.1" | 1        | "staging"    | _       | "release/1.x"              | "1.1.0-staging.2"
-        "1.1.0-staging.1" | 2        | "staging"    | _       | "release-1.x"              | "1.1.0-staging.2"
-        "1.0.1-staging.1" | 3        | "staging"    | _       | "release/1.0.x"            | "1.0.1-staging.2"
-        "1.0.1-staging.1" | 4        | "staging"    | _       | "release-1.0.x"            | "1.0.1-staging.2"
+        _             | _                 | 1        | "staging"    | _       | "master"                   | "0.1.0-staging.1"
+        _             | _                 | 2        | "staging"    | "major" | "master"                   | "1.0.0-staging.1"
+        _             | _                 | 3        | "staging"    | "minor" | "master"                   | "0.1.0-staging.1"
+        _             | _                 | 4        | "staging"    | "patch" | "master"                   | "0.0.1-staging.1"
 
-        "1.1.0-staging.1" | 1        | "staging"    | _       | "1.x"                      | "1.1.0-staging.2"
-        "1.0.1-staging.1" | 3        | "staging"    | _       | "1.0.x"                    | "1.0.1-staging.2"
+        '1.0.0'       | _                 | 1        | "staging"    | _       | "master"                   | "1.1.0-staging.1"
+        '1.0.0'       | _                 | 2        | "staging"    | "major" | "master"                   | "2.0.0-staging.1"
+        '1.0.0'       | _                 | 3        | "staging"    | "minor" | "master"                   | "1.1.0-staging.1"
+        '1.0.0'       | _                 | 4        | "staging"    | "patch" | "master"                   | "1.0.1-staging.1"
 
-        _                 | 1        | "rc"         | _       | "master"                   | "1.1.0-rc.1"
-        _                 | 2        | "rc"         | "major" | "master"                   | "2.0.0-rc.1"
-        _                 | 3        | "rc"         | "minor" | "master"                   | "1.1.0-rc.1"
-        _                 | 4        | "rc"         | "patch" | "master"                   | "1.0.1-rc.1"
+        '1.0.0'       | '1.1.0-staging.1' | 1        | "staging"    | _       | "master"                   | "1.1.0-staging.2"
+        '1.0.0'       | '1.1.0-staging.2' | 1        | "staging"    | _       | "master"                   | "1.1.0-staging.3"
 
-        '1.1.0-rc.1'      | 1        | "rc"         | _       | "master"                   | "1.1.0-rc.2"
-        '1.1.0-rc.2'      | 1        | "rc"         | _       | "master"                   | "1.1.0-rc.3"
+        '1.0.0'       | _                 | 1        | "staging"    | _       | "release/1.x"              | "1.1.0-staging.1"
+        '1.0.0'       | _                 | 2        | "staging"    | _       | "release-1.x"              | "1.1.0-staging.1"
+        '1.0.0'       | _                 | 3        | "staging"    | _       | "release/1.0.x"            | "1.0.1-staging.1"
+        '1.0.0'       | _                 | 4        | "staging"    | _       | "release-1.0.x"            | "1.0.1-staging.1"
 
-        _                 | 1        | "rc"         | _       | "release/1.x"              | "1.1.0-rc.1"
-        _                 | 2        | "rc"         | _       | "release-1.x"              | "1.1.0-rc.1"
-        _                 | 3        | "rc"         | _       | "release/1.0.x"            | "1.0.1-rc.1"
-        _                 | 4        | "rc"         | _       | "release-1.0.x"            | "1.0.1-rc.1"
+        '1.0.0'       | _                 | 1        | "staging"    | _       | "1.x"                      | "1.1.0-staging.1"
+        '1.0.0'       | _                 | 3        | "staging"    | _       | "1.0.x"                    | "1.0.1-staging.1"
 
-        _                 | 1        | "rc"         | _       | "1.x"                      | "1.1.0-rc.1"
-        _                 | 3        | "rc"         | _       | "1.0.x"                    | "1.0.1-rc.1"
+        '1.0.0'       | "1.1.0-staging.1" | 1        | "staging"    | _       | "release/1.x"              | "1.1.0-staging.2"
+        '1.0.0'       | "1.1.0-staging.1" | 2        | "staging"    | _       | "release-1.x"              | "1.1.0-staging.2"
+        '1.0.0'       | "1.0.1-staging.1" | 3        | "staging"    | _       | "release/1.0.x"            | "1.0.1-staging.2"
+        '1.0.0'       | "1.0.1-staging.1" | 4        | "staging"    | _       | "release-1.0.x"            | "1.0.1-staging.2"
 
-        "1.1.0-rc.1"      | 1        | "rc"         | _       | "release/1.x"              | "1.1.0-rc.2"
-        "1.1.0-rc.1"      | 2        | "rc"         | _       | "release-1.x"              | "1.1.0-rc.2"
-        "1.0.1-rc.1"      | 3        | "rc"         | _       | "release/1.0.x"            | "1.0.1-rc.2"
-        "1.0.1-rc.1"      | 4        | "rc"         | _       | "release-1.0.x"            | "1.0.1-rc.2"
+        '1.0.0'       | "1.1.0-staging.1" | 1        | "staging"    | _       | "1.x"                      | "1.1.0-staging.2"
+        '1.0.0'       | "1.0.1-staging.1" | 3        | "staging"    | _       | "1.0.x"                    | "1.0.1-staging.2"
 
-        "1.1.0-rc.1"      | 1        | "rc"         | _       | "1.x"                      | "1.1.0-rc.2"
-        "1.0.1-rc.1"      | 3        | "rc"         | _       | "1.0.x"                    | "1.0.1-rc.2"
+        _             | _                 | 1        | "rc"         | _       | "master"                   | "0.1.0-rc.1"
+        _             | _                 | 2        | "rc"         | "major" | "master"                   | "1.0.0-rc.1"
+        _             | _                 | 3        | "rc"         | "minor" | "master"                   | "0.1.0-rc.1"
+        _             | _                 | 4        | "rc"         | "patch" | "master"                   | "0.0.1-rc.1"
 
-        "1.1.0-rc.1"      | 1        | "staging"    | _       | "1.x"                      | "1.1.0-staging.1"
-        "1.0.1-rc.1"      | 3        | "staging"    | _       | "1.0.x"                    | "1.0.1-staging.1"
+        '1.0.0'       | _                 | 1        | "rc"         | _       | "master"                   | "1.1.0-rc.1"
+        '1.0.0'       | _                 | 2        | "rc"         | "major" | "master"                   | "2.0.0-rc.1"
+        '1.0.0'       | _                 | 3        | "rc"         | "minor" | "master"                   | "1.1.0-rc.1"
+        '1.0.0'       | _                 | 4        | "rc"         | "patch" | "master"                   | "1.0.1-rc.1"
 
-        _                 | 1        | "production" | _       | "master"                   | "1.1.0"
-        _                 | 2        | "production" | "major" | "master"                   | "2.0.0"
-        _                 | 3        | "production" | "minor" | "master"                   | "1.1.0"
-        _                 | 4        | "production" | "patch" | "master"                   | "1.0.1"
+        '1.0.0'       | '1.1.0-rc.1'      | 1        | "rc"         | _       | "master"                   | "1.1.0-rc.2"
+        '1.0.0'       | '1.1.0-rc.2'      | 1        | "rc"         | _       | "master"                   | "1.1.0-rc.3"
 
-        _                 | 1        | "production" | _       | "release/1.x"              | "1.1.0"
-        _                 | 1        | "production" | _       | "release/1.x"              | "1.1.0"
-        _                 | 2        | "production" | _       | "release-1.x"              | "1.1.0"
-        _                 | 3        | "production" | _       | "release/1.0.x"            | "1.0.1"
-        _                 | 4        | "production" | _       | "release-1.0.x"            | "1.0.1"
+        '1.0.0'       | _                 | 1        | "rc"         | _       | "release/1.x"              | "1.1.0-rc.1"
+        '1.0.0'       | _                 | 2        | "rc"         | _       | "release-1.x"              | "1.1.0-rc.1"
+        '1.0.0'       | _                 | 3        | "rc"         | _       | "release/1.0.x"            | "1.0.1-rc.1"
+        '1.0.0'       | _                 | 4        | "rc"         | _       | "release-1.0.x"            | "1.0.1-rc.1"
 
-        _                 | 1        | "production" | _       | "1.x"                      | "1.1.0"
-        _                 | 3        | "production" | _       | "1.0.x"                    | "1.0.1"
+        '1.0.0'       | _                 | 1        | "rc"         | _       | "1.x"                      | "1.1.0-rc.1"
+        '1.0.0'       | _                 | 3        | "rc"         | _       | "1.0.x"                    | "1.0.1-rc.1"
 
-        _                 | 1        | "final"      | _       | "master"                   | "1.1.0"
-        _                 | 2        | "final"      | "major" | "master"                   | "2.0.0"
-        _                 | 3        | "final"      | "minor" | "master"                   | "1.1.0"
-        _                 | 4        | "final"      | "patch" | "master"                   | "1.0.1"
+        '1.0.0'       | "1.1.0-rc.1"      | 1        | "rc"         | _       | "release/1.x"              | "1.1.0-rc.2"
+        '1.0.0'       | "1.1.0-rc.1"      | 2        | "rc"         | _       | "release-1.x"              | "1.1.0-rc.2"
+        '1.0.0'       | "1.0.1-rc.1"      | 3        | "rc"         | _       | "release/1.0.x"            | "1.0.1-rc.2"
+        '1.0.0'       | "1.0.1-rc.1"      | 4        | "rc"         | _       | "release-1.0.x"            | "1.0.1-rc.2"
 
-        _                 | 1        | "final"      | _       | "release/1.x"              | "1.1.0"
-        _                 | 1        | "final"      | _       | "release/1.x"              | "1.1.0"
-        _                 | 2        | "final"      | _       | "release-1.x"              | "1.1.0"
-        _                 | 3        | "final"      | _       | "release/1.0.x"            | "1.0.1"
-        _                 | 4        | "final"      | _       | "release-1.0.x"            | "1.0.1"
+        '1.0.0'       | "1.1.0-rc.1"      | 1        | "rc"         | _       | "1.x"                      | "1.1.0-rc.2"
+        '1.0.0'       | "1.0.1-rc.1"      | 3        | "rc"         | _       | "1.0.x"                    | "1.0.1-rc.2"
 
-        _                 | 1        | "final"      | _       | "1.x"                      | "1.1.0"
-        _                 | 3        | "final"      | _       | "1.0.x"                    | "1.0.1"
+        '1.0.0'       | "1.1.0-rc.1"      | 1        | "staging"    | _       | "1.x"                      | "1.1.0-staging.1"
+        '1.0.0'       | "1.0.1-rc.1"      | 3        | "staging"    | _       | "1.0.x"                    | "1.0.1-staging.1"
 
-        _                 | 1        | "final"      | _       | "1.x"                      | "1.1.0"
-        _                 | 3        | "final"      | _       | "1.0.x"                    | "1.0.1"
-        _                 | 10       | "ci"         | _       | "test/build01-"            | "1.1.0-branch.test.build.1.10"
-        _                 | 22       | "ci"         | _       | "test/build01+"            | "1.1.0-branch.test.build.1.22"
-        _                 | 45       | "ci"         | _       | "test/build01_"            | "1.1.0-branch.test.build.1.45"
-        _                 | 204      | "ci"         | _       | "test/build01"             | "1.1.0-branch.test.build.1.204"
-        _                 | 100      | "ci"         | _       | "test/build.01"            | "1.1.0-branch.test.build.1.100"
-        _                 | 55       | "ci"         | _       | "test/build002"            | "1.1.0-branch.test.build.2.55"
-        _                 | 66       | "ci"         | _       | "test/build.002"           | "1.1.0-branch.test.build.2.66"
-        _                 | 789      | "ci"         | _       | "test/build000000000003"   | "1.1.0-branch.test.build.3.789"
-        _                 | 777      | "ci"         | _       | "test/build.000000000003"  | "1.1.0-branch.test.build.3.777"
-        _                 | 789      | "ci"         | _       | "test/build000000.000003"  | "1.1.0-branch.test.build.0.3.789"
-        _                 | 3        | "ci"         | _       | "test/build.000000.000003" | "1.1.0-branch.test.build.0.3.3"
-        _                 | 3        | "ci"         | _       | "release/1.00.x"           | "1.0.1-branch.release.1.0.x.3"
+        _             | _                 | 1        | "production" | _       | "master"                   | "0.1.0"
+        _             | _                 | 2        | "production" | "major" | "master"                   | "1.0.0"
+        _             | _                 | 3        | "production" | "minor" | "master"                   | "0.1.0"
+        _             | _                 | 4        | "production" | "patch" | "master"                   | "0.0.1"
 
-        nearestNormal = '1.0.0'
+        '1.0.0'       | _                 | 1        | "production" | _       | "master"                   | "1.1.0"
+        '1.0.0'       | _                 | 2        | "production" | "major" | "master"                   | "2.0.0"
+        '1.0.0'       | _                 | 3        | "production" | "minor" | "master"                   | "1.1.0"
+        '1.0.0'       | _                 | 4        | "production" | "patch" | "master"                   | "1.0.1"
+
+        '1.0.0'       | _                 | 1        | "production" | _       | "release/1.x"              | "1.1.0"
+        '1.0.0'       | _                 | 1        | "production" | _       | "release/1.x"              | "1.1.0"
+        '1.0.0'       | _                 | 2        | "production" | _       | "release-1.x"              | "1.1.0"
+        '1.0.0'       | _                 | 3        | "production" | _       | "release/1.0.x"            | "1.0.1"
+        '1.0.0'       | _                 | 4        | "production" | _       | "release-1.0.x"            | "1.0.1"
+
+        '1.0.0'       | _                 | 1        | "production" | _       | "1.x"                      | "1.1.0"
+        '1.0.0'       | _                 | 3        | "production" | _       | "1.0.x"                    | "1.0.1"
+
+        _             | _                 | 1        | "final"      | _       | "master"                   | "0.1.0"
+        _             | _                 | 2        | "final"      | "major" | "master"                   | "1.0.0"
+        _             | _                 | 3        | "final"      | "minor" | "master"                   | "0.1.0"
+        _             | _                 | 4        | "final"      | "patch" | "master"                   | "0.0.1"
+
+        '1.0.0'       | _                 | 1        | "final"      | _       | "master"                   | "1.1.0"
+        '1.0.0'       | _                 | 2        | "final"      | "major" | "master"                   | "2.0.0"
+        '1.0.0'       | _                 | 3        | "final"      | "minor" | "master"                   | "1.1.0"
+        '1.0.0'       | _                 | 4        | "final"      | "patch" | "master"                   | "1.0.1"
+
+        '1.0.0'       | _                 | 1        | "final"      | _       | "release/1.x"              | "1.1.0"
+        '1.0.0'       | _                 | 1        | "final"      | _       | "release/1.x"              | "1.1.0"
+        '1.0.0'       | _                 | 2        | "final"      | _       | "release-1.x"              | "1.1.0"
+        '1.0.0'       | _                 | 3        | "final"      | _       | "release/1.0.x"            | "1.0.1"
+        '1.0.0'       | _                 | 4        | "final"      | _       | "release-1.0.x"            | "1.0.1"
+
+        '1.0.0'       | _                 | 1        | "final"      | _       | "1.x"                      | "1.1.0"
+        '1.0.0'       | _                 | 3        | "final"      | _       | "1.0.x"                    | "1.0.1"
+
+        '1.0.0'       | _                 | 1        | "final"      | _       | "1.x"                      | "1.1.0"
+        '1.0.0'       | _                 | 3        | "final"      | _       | "1.0.x"                    | "1.0.1"
+        '1.0.0'       | _                 | 10       | "ci"         | _       | "test/build01-"            | "1.1.0-branch.test.build.1.10"
+        '1.0.0'       | _                 | 22       | "ci"         | _       | "test/build01+"            | "1.1.0-branch.test.build.1.22"
+        '1.0.0'       | _                 | 45       | "ci"         | _       | "test/build01_"            | "1.1.0-branch.test.build.1.45"
+        '1.0.0'       | _                 | 204      | "ci"         | _       | "test/build01"             | "1.1.0-branch.test.build.1.204"
+        '1.0.0'       | _                 | 100      | "ci"         | _       | "test/build.01"            | "1.1.0-branch.test.build.1.100"
+        '1.0.0'       | _                 | 55       | "ci"         | _       | "test/build002"            | "1.1.0-branch.test.build.2.55"
+        '1.0.0'       | _                 | 66       | "ci"         | _       | "test/build.002"           | "1.1.0-branch.test.build.2.66"
+        '1.0.0'       | _                 | 789      | "ci"         | _       | "test/build000000000003"   | "1.1.0-branch.test.build.3.789"
+        '1.0.0'       | _                 | 777      | "ci"         | _       | "test/build.000000000003"  | "1.1.0-branch.test.build.3.777"
+        '1.0.0'       | _                 | 789      | "ci"         | _       | "test/build000000.000003"  | "1.1.0-branch.test.build.0.3.789"
+        '1.0.0'       | _                 | 3        | "ci"         | _       | "test/build.000000.000003" | "1.1.0-branch.test.build.0.3.3"
+        '1.0.0'       | _                 | 3        | "ci"         | _       | "release/1.00.x"           | "1.0.1-branch.release.1.0.x.3"
+
+        '1.0.0'       | _                 | 10       | "ci"         | _       | "test/build01-"            | "1.1.0-branch.test.build.1.10"
+        '1.0.0'       | _                 | 22       | "ci"         | _       | "test/build01+"            | "1.1.0-branch.test.build.1.22"
+        '1.0.0'       | _                 | 45       | "ci"         | _       | "test/build01_"            | "1.1.0-branch.test.build.1.45"
+        '1.0.0'       | _                 | 204      | "ci"         | _       | "test/build01"             | "1.1.0-branch.test.build.1.204"
+        '1.0.0'       | _                 | 100      | "ci"         | _       | "test/build.01"            | "1.1.0-branch.test.build.1.100"
+        '1.0.0'       | _                 | 55       | "ci"         | _       | "test/build002"            | "1.1.0-branch.test.build.2.55"
+        '1.0.0'       | _                 | 66       | "ci"         | _       | "test/build.002"           | "1.1.0-branch.test.build.2.66"
+        '1.0.0'       | _                 | 789      | "ci"         | _       | "test/build000000000003"   | "1.1.0-branch.test.build.3.789"
+        '1.0.0'       | _                 | 777      | "ci"         | _       | "test/build.000000000003"  | "1.1.0-branch.test.build.3.777"
+        '1.0.0'       | _                 | 789      | "ci"         | _       | "test/build000000.000003"  | "1.1.0-branch.test.build.0.3.789"
+        '1.0.0'       | _                 | 3        | "ci"         | _       | "test/build.000000.000003" | "1.1.0-branch.test.build.0.3.3"
+        '1.0.0'       | _                 | 3        | "ci"         | _       | "release/1.00.x"           | "1.0.1-branch.release.1.0.x.3"
+
         nearestAnyTitle = (nearestAny == _) ? "unset" : nearestAny
         scopeTitle = (scope == _) ? "unset" : scope
     }
@@ -880,7 +951,6 @@ class VersionPluginSpec extends ProjectSpec {
         _                 | "0.2.0"  | _                | 3        | 0                  | "ci"         | "test/build.000000.000003" | _                            | _                       | "0.2.0-branch.test.build.0.3.3"
         _                 | "0.2.0"  | "0.1.0"          | 3        | 0                  | "ci"         | "release/1.00.x"           | _                            | _                       | "0.1.0-branch.release.1.0.x.3"
 
-        nearestNormal = '1.0.0'
         productionMarkerTitle = (productionMarker == _) ? "unset" : productionMarker
         ciMarkerTitle = (ciMarker == _) ? "unset" : ciMarker
     }
@@ -901,11 +971,13 @@ class VersionPluginSpec extends ProjectSpec {
             git.checkout(branch: "$branchName", startPoint: 'master', createBranch: true)
         }
 
-        5.times {
-            git.commit(message: 'feature commit')
-        }
 
-        git.tag.add(name: "$tagPrefix$nearestNormal")
+        if(nearestNormal != _) {
+            5.times {
+                git.commit(message: 'feature commit')
+            }
+            git.tag.add(name: "$tagPrefix$nearestNormal")
+        }
 
         distance.times {
             git.commit(message: 'fix commit')
@@ -925,13 +997,13 @@ class VersionPluginSpec extends ProjectSpec {
         project.version.toString() == expectedVersion
 
         where:
-        nearestAny | distance | stage      | scope | scheme                | branchName | prefixTag | expectedVersion
-        _          | 1        | "ci"       | _     | VersionScheme.semver2 | "master"   | true      | "1.1.0-master.1"
-        _          | 1        | "ci"       | _     | VersionScheme.semver2 | "master"   | false     | "1.1.0-master.1"
-        _          | 1        | "snapshot" | _     | VersionScheme.semver  | "master"   | true      | "1.0.1-master00001"
-        _          | 1        | "snapshot" | _     | VersionScheme.semver  | "master"   | false     | "1.0.1-master00001"
-
-        nearestNormal = '1.0.0'
+        nearestNormal | nearestAny | distance | stage      | scope | scheme                | branchName | prefixTag | expectedVersion
+        '1.0.0'       | _          | 1        | "ci"       | _     | VersionScheme.semver2 | "master"   | true      | "1.1.0-master.1"
+        '1.0.0'       | _          | 1        | "ci"       | _     | VersionScheme.semver2 | "master"   | false     | "1.1.0-master.1"
+        '1.0.0'       | _          | 1        | "snapshot" | _     | VersionScheme.semver  | "master"   | true      | "1.0.1-master00001"
+        '1.0.0'       | _          | 1        | "snapshot" | _     | VersionScheme.semver  | "master"   | false     | "1.0.1-master00001"
+        _             | _          | 1        | "ci"       | _     | VersionScheme.semver2 | "master"   | false     | "0.1.0-master.2"
+        _             | _          | 1        | "snapshot" | _     | VersionScheme.semver  | "master"   | false     | "0.0.1-master00002"
         nearestAnyTitle = (nearestAny == _) ? "unset" : nearestAny
         scopeTitle = (scope == _) ? "unset" : scope
         tagPrefix = (prefixTag) ? "v" : ""


### PR DESCRIPTION
## Description
The `previousVersion` field from Extension's `version` property returned `"0.0.0"` on cases where it couldn't find a previous version (ie. there are no version git tags in the git repository). This causes problems when integrating with other plugins. For instance, `GithubRelease` in atlas-github tries to find the "0.0.0" and crashes in the process. 

To better reflect the lack of previous version tags, `previousVersion` is now set to `null` when this case happens. Several tests were also updated to cover cases for generating version when there are no git version tags present.


## Changes
* ![IMPROVE] `version.previousVersion` now is `null` instead of `"0.0.0"` when there are no version tags.

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"
