### PR TITLE
Add snyk integration [ATLAS-712]

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,6 +19,7 @@
 @Library('github.com/wooga/atlas-jenkins-pipeline@1.x') _
 
 withCredentials([string(credentialsId: 'atlas_version_coveralls_token', variable: 'coveralls_token'),
-                 string(credentialsId: 'atlas_plugins_sonar_token', variable: 'sonar_token')]) {
+                string(credentialsId: 'atlas_plugins_sonar_token', variable: 'sonar_token'),
+                string(credentialsId: 'atlas_plugins_snyk_token', variable: 'SNYK_TOKEN')]) {
     buildGradlePlugin platforms: ['macos','linux','windows'], coverallsToken: coveralls_token, sonarToken: sonar_token
 }

--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,9 @@ buildscript {
 
 plugins {
     id 'net.wooga.plugins' version '2.2.4'
+    id 'net.wooga.snyk' version '0.10.0'
+    id "net.wooga.snyk-gradle-plugin" version "0.2.0"
+    id "net.wooga.cve-dependency-resolution" version "0.4.0"
     id 'java-library'
 }
 
@@ -51,16 +54,13 @@ github {
 
 dependencies {
     implementation 'com.github.zafarkhaja:java-semver:0.9.0'
-    implementation 'org.ajoberstar.grgit:grgit-core:4.1.1'
+    implementation 'org.ajoberstar.grgit:grgit-core:[4.1.1,5['
     implementation 'com.google.guava:guava:23.0'
-    implementation 'com.wooga.gradle:gradle-commons:(1, 2]'
+    implementation 'com.wooga.gradle:gradle-commons:[1,2['
 
-    testImplementation 'com.wooga.gradle:gradle-commons-test:(1,2]'
-    testImplementation 'com.github.stefanbirkner:system-rules:1.18.0'
+    testImplementation 'com.wooga.gradle:gradle-commons-test:[1,2['
 }
 
-configurations.all {
-    resolutionStrategy {
-        force 'org.codehaus.groovy:groovy-all:2.5.12'
-    }
+cveHandler {
+    configurations("compileClasspath", "runtimeClasspath", "testCompileClasspath", "testRuntimeClasspath", "integrationTestCompileClasspath", "integrationTestRuntimeClasspath")
 }


### PR DESCRIPTION
## Decription

This patch adds snyk monitoring to the build pipeline. It will hook itself into the check and publish stages.

The patch also sets a dependency helper plugin net.wooga.cve-dependency-resolution which applies overrides for dependencies with know fixes for security issues.

## Changes

* ![ADD] `snyk` monitoring
* ![ADD] `net.wooga.snyk-wdk-java` snyk convention plugin
* ![ADD] `net.wogoa.cve-dependency-resolution` plugin

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
