### PR TITLE
Add a way to set the version by string by script, property or environ…

### DIFF
--- a/src/main/groovy/wooga/gradle/version/VersionPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/version/VersionPlugin.groovy
@@ -75,7 +75,7 @@ class VersionPlugin implements Plugin<Project> {
 
         extension.versionScheme.set(VersionPluginConventions.versionScheme.getStringValueProvider(project).map({
             VersionScheme.valueOf(it.trim())
-            }))
+        }))
 
         extension.versionCodeScheme.set(VersionPluginConventions.versionCodeScheme.getStringValueProvider(project).map({
             VersionCodeScheme.valueOf(it.trim())

--- a/src/main/groovy/wooga/gradle/version/VersionPluginConventions.groovy
+++ b/src/main/groovy/wooga/gradle/version/VersionPluginConventions.groovy
@@ -25,6 +25,7 @@ class VersionPluginConventions {
     static final String GIT_ROOT_PROPERTY = "git.root"
     static final String UNINITIALIZED_VERSION = '0.1.0-dev.0.uninitialized'
 
+    static final PropertyLookup version = new PropertyLookup("VERSION_BUILDER_VERSION", "versionBuilder.version", null)
     static final PropertyLookup versionScheme = new PropertyLookup("VERSION_BUILDER_VERSION_SCHEME", ["versionBuilder.versionScheme", "version.scheme"], VersionScheme.semver)
     static final PropertyLookup versionCodeScheme = new PropertyLookup("VERSION_BUILDER_VERSION_CODE_SCHEME", "versionBuilder.versionCodeScheme", VersionCodeScheme.none)
     static final PropertyLookup versionCodeOffset = new PropertyLookup("VERSION_BUILDER_VERSION_CODE_OFFSET", "versionBuilder.versionCodeOffset", 0)

--- a/src/main/groovy/wooga/gradle/version/VersionPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/version/VersionPluginExtension.groovy
@@ -19,16 +19,12 @@
 package wooga.gradle.version
 
 import com.wooga.gradle.BaseSpec
-import org.gradle.api.provider.ProviderFactory
-import wooga.gradle.version.internal.release.base.ReleaseVersion
-import wooga.gradle.version.internal.release.base.TagStrategy
-import wooga.gradle.version.internal.release.semver.ChangeScope
 import org.ajoberstar.grgit.Grgit
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
-import wooga.gradle.version.internal.release.semver.SemVerStrategy
-import wooga.gradle.version.internal.release.semver.SemVerStrategyState
-import wooga.gradle.version.strategies.SemverV2Strategies
+import wooga.gradle.version.internal.release.base.ReleaseVersion
+import wooga.gradle.version.internal.release.base.TagStrategy
+import wooga.gradle.version.internal.release.semver.ChangeScope
 
 trait VersionPluginExtension implements BaseSpec {
 
@@ -193,6 +189,10 @@ trait VersionPluginExtension implements BaseSpec {
 
     void setVersion(Provider<ReleaseVersion> value) {
         version = value
+    }
+
+    void setVersion(String value) {
+        version = providers.provider({ new ReleaseVersion(version: value) })
     }
 
     /**

--- a/src/main/groovy/wooga/gradle/version/internal/DefaultVersionPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/version/internal/DefaultVersionPluginExtension.groovy
@@ -167,7 +167,9 @@ class DefaultVersionPluginExtension implements VersionPluginExtension {
         releaseBranchPattern.set(VersionPluginConventions.releaseBranchPattern.getStringValueProvider(project))
         mainBranchPattern.set(VersionPluginConventions.mainBranchPattern.getStringValueProvider(project))
 
-        version = project.provider({
+        version = VersionPluginConventions.version.getStringValueProvider(project).map({
+            new ReleaseVersion(version:it)
+        }).orElse(project.provider({
             def versionStrategies = versionStrategies.get()
             def defaultStrategy = defaultStrategy.get()
             def git = git.getOrNull()
@@ -195,7 +197,7 @@ class DefaultVersionPluginExtension implements VersionPluginExtension {
             } else {
                 new ReleaseVersion(version: VersionPluginConventions.UNINITIALIZED_VERSION)
             }
-        }.memoize())
+        }.memoize()))
 
         versionCode = versionCodeScheme.map({ scheme ->
             def offset = versionCodeOffset.getOrElse(0)

--- a/src/test/groovy/wooga/gradle/version/VersionPluginSpec.groovy
+++ b/src/test/groovy/wooga/gradle/version/VersionPluginSpec.groovy
@@ -1007,4 +1007,20 @@ class VersionPluginSpec extends ProjectSpec {
         "with_underscore"   | "1.0.1-branchWithUnderscore00001"
         "with-dash"         | "1.0.1-branchWithDash00001"
     }
+
+    def "can set custom version directly by property in provided extension"() {
+        given:
+        project.plugins.apply(PLUGIN_NAME)
+        def extension = project.extensions.getByType(VersionCodeExtension)
+
+        when:
+        project.ext.set(propertyName, version)
+
+        then:
+        project.property("version").get() == version
+
+        where:
+        propertyName             | version
+        "versionBuilder.version" | "1.2.3"
+    }
 }


### PR DESCRIPTION
## Description

Adds a few ways to set the version of the project directly by string via property or environment variable. This is especially useful during development.

## Changes
* ![ADD] Methods to set the extension `version` by string.

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"
