### PR TITLE
Fix bug where plugin breaks on empty scope

### DIFF
--- a/src/integrationTest/groovy/wooga/gradle/version/VersionPluginExtensionIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/version/VersionPluginExtensionIntegrationSpec.groovy
@@ -1,0 +1,78 @@
+package wooga.gradle.version
+
+import com.wooga.gradle.test.PropertyLocation
+import com.wooga.gradle.test.writers.PropertyGetterTaskWriter
+import com.wooga.gradle.test.writers.PropertySetterWriter
+import org.gradle.api.file.Directory
+import spock.lang.Unroll
+
+class VersionPluginExtensionIntegrationSpec extends VersionIntegrationSpec {
+
+    def setup() {
+        buildFile << """
+            ${applyPlugin(VersionPlugin)}
+        """.stripIndent()
+    }
+
+    @Unroll("can set property versionBuilder.#property with gradle property #gradlePropName=#rawValue")
+    def "can set extension property with gradle property"() {
+        given:
+        set.location = rawValue == null ? PropertyLocation.none : set.location
+        when:
+        def propertyQuery = runPropertyQuery(get, set).withSerializer(Directory) {
+            String dir -> new File(projectDir, dir).absolutePath
+        }
+
+        then:
+        propertyQuery.matches(expectedValue)
+
+        where:
+        property | gradlePropName  | type   | rawValue   | expectedValue
+        "stage"  | "release.stage" | String | "snapshot" | "snapshot"
+        "stage"  | "release.stage" | String | "rc"       | "rc"
+        "stage"  | "release.stage" | String | "final"    | "final"
+        "stage"  | "release.stage" | String | "custom"   | "custom"
+        "stage"  | "release.stage" | String | null       | null
+        "scope"  | "release.scope" | String | "major"    | "MAJOR"
+        "scope"  | "release.scope" | String | "minor"    | "MINOR"
+        "scope"  | "release.scope" | String | "patch"    | "PATCH"
+        "scope"  | "release.scope" | String | "PatCh"    | "PATCH"
+        "scope"  | "release.scope" | String | "PATCH"    | "PATCH"
+        "scope"  | "release.scope" | String | null       | null
+
+
+        set = new PropertySetterWriter("versionBuilder", property)
+                .set(rawValue, type)
+                .withPropertyKey(gradlePropName)
+                .to(PropertyLocation.propertyCommandLine)
+        get = new PropertyGetterTaskWriter(set)
+    }
+
+    //Line bellow doesn't work on gradle-commons-test framework so I'm doing it myself.
+    //        "stage"  | "release.stage" | String | ""       | null
+    @Unroll("can set property versionBuilder.#property with gradle property #gradlePropName=#rawValue")
+    def "can set extension property with gradle property but w/out gradle-commons-test"() {
+        given:
+        buildFile << """
+            tasks.register("$taskName") {
+                doLast {
+                    println("[[[$gradlePropName=\${versionBuilder.${property}.orNull}]]]")
+                }
+            }
+        """
+
+        when:
+        def result = runTasks(taskName, "-P${gradlePropName}=${rawValue}",)
+
+        then:
+        result.standardOutput.contains("[[[${gradlePropName}=${expectedValue}]]]")
+
+        where:
+        property | gradlePropName  | type   | rawValue | expectedValue
+        "stage"  | "release.stage" | String | ""       | ""
+        "scope"  | "release.scope" | String | ""       | null
+        taskName = "getterTask"
+    }
+
+
+}

--- a/src/main/groovy/wooga/gradle/version/internal/DefaultVersionPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/version/internal/DefaultVersionPluginExtension.groovy
@@ -36,9 +36,9 @@ class DefaultVersionPluginExtension implements VersionPluginExtension {
     DefaultVersionPluginExtension(Project project) {
         this.project = project
 
-        scope = VersionPluginConventions.scope.getStringValueProvider(project).map {
-            ChangeScope.valueOf(it.toUpperCase())
-        }
+        scope = VersionPluginConventions.scope.getStringValueProvider(project)
+        .map {it?.trim()?.empty? null: it }
+        .map {ChangeScope.valueOf(it.toUpperCase()) }
 
         stage = VersionPluginConventions.stage.getStringValueProvider(project)
         releaseBranchPattern.set(VersionPluginConventions.releaseBranchPattern.getStringValueProvider(project))

--- a/src/test/groovy/wooga/gradle/version/VersionPluginSpec.groovy
+++ b/src/test/groovy/wooga/gradle/version/VersionPluginSpec.groovy
@@ -101,10 +101,6 @@ class VersionPluginSpec extends ProjectSpec {
         'versionBuilder' | VersionPluginExtension
     }
 
-    def findStrategyByName(List<VersionStrategy> strategies, name) {
-        strategies.find { it.name == name }
-    }
-
     @Unroll('verify wooga packages version strategy for #tagVersion, #scope and #stage')
     def "uses custom wooga semver strategies"() {
 


### PR DESCRIPTION
## Description
On the previous refactor the release scope now maps to the ChangeScope enum. Thing is, support for empty release scopes passed through command line  wasn't present, which is a bug, and it wasn't covered by tests. 

## Changes
* ![FIX] `-Prelease.scope` did not support empty values.



[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"
