### PR TITLE
Add a log entry detailing the repository status if it's found dirty

### DIFF
--- a/src/test/groovy/wooga/gradle/version/internal/SemVerStrategySpec.groovy
+++ b/src/test/groovy/wooga/gradle/version/internal/SemVerStrategySpec.groovy
@@ -1,0 +1,41 @@
+package wooga.gradle.version.internal
+
+import org.ajoberstar.grgit.Status
+import spock.lang.Specification
+import wooga.gradle.version.internal.release.semver.SemVerStrategy
+
+class SemVerStrategySpec extends Specification {
+
+    Map changes() {
+        Map result = [:]
+        result["added"] = []
+        result["modified"] = []
+        result["removed"] = []
+        result
+    }
+
+    def "generates status string"() {
+        given:
+        def args = [:]
+
+        def staged = changes()
+        staged["added"] = ["foo"]
+        args["staged"] = staged
+
+        def unstaged = changes()
+        unstaged["removed"] = ["bar"]
+        args["unstaged"] = unstaged
+
+        def conflicts = []
+        args["conflicts"] = conflicts
+
+        def status = new Status(args)
+
+        when:
+        def str = SemVerStrategy.composeRepositoryStatus(status)
+
+        then:
+        str.contains("[ADDED] foo")
+        str.contains("[REMOVED] bar")
+    }
+}


### PR DESCRIPTION
## Description
Adds a log info message that details the repository staged/unstaged sets if the repository is found dirty. This is to help debug when it is do during builds.

## Changes
* ![ADD] `SemVerStrategy` log for repository status when found dirty

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"
