### PR TITLE
Smaller pending breaking change refactors

### DIFF
--- a/src/integrationTest/groovy/wooga/gradle/version/VersionIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/version/VersionIntegrationSpec.groovy
@@ -31,10 +31,10 @@ class VersionIntegrationSpec extends IntegrationSpec {
     static wrapValueFallback = { Object rawValue, String type, Closure<String> fallback ->
         switch (type) {
             case "VersionScheme":
-                if(VersionScheme.isInstance(rawValue)) {
-                    return "wooga.gradle.version.VersionScheme.${rawValue.toString()}"
+                if(VersionSchemes.isInstance(rawValue)) {
+                    return "wooga.gradle.version.VersionSchemes.${rawValue.toString()}"
                 } else {
-                    return "wooga.gradle.version.VersionScheme.valueOf('${rawValue.toString()}')"
+                    return "wooga.gradle.version.VersionSchemes.valueOf('${rawValue.toString()}')"
                 }
                 break
             case "VersionCodeScheme":

--- a/src/integrationTest/groovy/wooga/gradle/version/VersionPluginIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/version/VersionPluginIntegrationSpec.groovy
@@ -17,7 +17,6 @@
 package wooga.gradle.version
 
 import com.wooga.gradle.PlatformUtils
-import com.wooga.gradle.PropertyLookup
 import com.wooga.gradle.test.PropertyLocation
 import com.wooga.gradle.test.PropertyQueryTaskWriter
 import wooga.gradle.version.internal.release.semver.ChangeScope
@@ -100,10 +99,10 @@ class VersionPluginIntegrationSpec extends VersionIntegrationSpec {
         "stage"                | "snapshot"          | _                                   | PropertyLocation.environment
         "stage"                | "final"             | _                                   | PropertyLocation.property
         "stage"                | "null"              | _                                   | PropertyLocation.none
-        "versionScheme"        | "semver2"           | VersionScheme.semver2               | PropertyLocation.environment
-        "versionScheme"        | "semver"            | VersionScheme.semver                | PropertyLocation.environment
-        "versionScheme"        | "semver2"           | VersionScheme.semver2               | PropertyLocation.property
-        "versionScheme"        | "semver"            | VersionScheme.semver                | PropertyLocation.property
+        "versionScheme"        | "semver2"           | VersionSchemes.semver2 | PropertyLocation.environment
+        "versionScheme"        | "semver"            | VersionSchemes.semver  | PropertyLocation.environment
+        "versionScheme"        | "semver2"           | VersionSchemes.semver2 | PropertyLocation.property
+        "versionScheme"        | "semver"            | VersionSchemes.semver  | PropertyLocation.property
         "versionCodeScheme"    | "releaseCountBasic" | VersionCodeScheme.releaseCountBasic | PropertyLocation.environment
         "versionCodeScheme"    | "releaseCount"      | VersionCodeScheme.releaseCount      | PropertyLocation.environment
         "versionCodeScheme"    | "semver"            | VersionCodeScheme.semver            | PropertyLocation.environment
@@ -155,15 +154,15 @@ class VersionPluginIntegrationSpec extends VersionIntegrationSpec {
         where:
         property               | method                     | rawValue                            | type
         "versionScheme"        | "versionScheme"            | "semver"                            | "String"
-        "versionScheme"        | "versionScheme"            | VersionScheme.semver2               | "VersionScheme"
-        "versionScheme"        | "versionScheme"            | VersionScheme.semver                | "Provider<VersionScheme>"
-        "versionScheme"        | "versionScheme"            | VersionScheme.staticMarker          | "Provider<VersionScheme>"
-        "versionScheme"        | "versionScheme.set"        | VersionScheme.semver2               | "VersionScheme"
-        "versionScheme"        | "versionScheme.set"        | VersionScheme.semver                | "Provider<VersionScheme>"
-        "versionScheme"        | "versionScheme.set"        | VersionScheme.staticMarker          | "Provider<VersionScheme>"
+        "versionScheme"        | "versionScheme"            | VersionSchemes.semver2      | "VersionScheme"
+        "versionScheme"        | "versionScheme"            | VersionSchemes.semver       | "Provider<VersionScheme>"
+        "versionScheme"        | "versionScheme"            | VersionSchemes.staticMarker | "Provider<VersionScheme>"
+        "versionScheme"        | "versionScheme.set"        | VersionSchemes.semver2      | "VersionScheme"
+        "versionScheme"        | "versionScheme.set"        | VersionSchemes.semver       | "Provider<VersionScheme>"
+        "versionScheme"        | "versionScheme.set"        | VersionSchemes.staticMarker | "Provider<VersionScheme>"
         "versionScheme"        | "setVersionScheme"         | "semver"                            | "String"
-        "versionScheme"        | "setVersionScheme"         | VersionScheme.semver2               | "VersionScheme"
-        "versionScheme"        | "setVersionScheme"         | VersionScheme.semver                | "Provider<VersionScheme>"
+        "versionScheme"        | "setVersionScheme"         | VersionSchemes.semver2      | "VersionScheme"
+        "versionScheme"        | "setVersionScheme"         | VersionSchemes.semver       | "Provider<VersionScheme>"
 
         "versionCodeScheme"    | "versionCodeScheme"        | "releaseCountBasic"                 | "String"
         "versionCodeScheme"    | "versionCodeScheme"        | VersionCodeScheme.semver            | "VersionCodeScheme"

--- a/src/main/groovy/wooga/gradle/version/VersionCodeScheme.groovy
+++ b/src/main/groovy/wooga/gradle/version/VersionCodeScheme.groovy
@@ -21,7 +21,7 @@ package wooga.gradle.version
 import org.ajoberstar.grgit.Grgit
 import wooga.gradle.version.internal.VersionCode
 import wooga.gradle.version.internal.release.git.GitVersionRepository
-import wooga.gradle.version.internal.release.git.PrefixTagStrategy
+import wooga.gradle.version.internal.release.base.PrefixVersionParser
 
 enum VersionCodeScheme {
     none({ -> 0}),
@@ -33,12 +33,12 @@ enum VersionCodeScheme {
     }),
     releaseCountBasic({ Grgit git, int offset ->
         //Tag strategy here hardcoded for backwards compatibility
-        def versionRepo = GitVersionRepository.fromTagStrategy(git, new PrefixTagStrategy("v", false))
+        def versionRepo = GitVersionRepository.fromTagStrategy(git, new PrefixVersionParser("v", false))
          VersionCode.generateBuildNumberVersionCode(versionRepo, false, offset)
     }),
     releaseCount({ Grgit git, int offset ->
             //Tag strategy here hardcoded for backwards compatibility
-            def versionRepo = GitVersionRepository.fromTagStrategy(git, new PrefixTagStrategy("v", false))
+            def versionRepo = GitVersionRepository.fromTagStrategy(git, new PrefixVersionParser("v", false))
             VersionCode.generateBuildNumberVersionCode(versionRepo, true, offset)
     })
 

--- a/src/main/groovy/wooga/gradle/version/VersionCodeScheme.groovy
+++ b/src/main/groovy/wooga/gradle/version/VersionCodeScheme.groovy
@@ -18,35 +18,10 @@
 
 package wooga.gradle.version
 
-import org.ajoberstar.grgit.Grgit
-import wooga.gradle.version.internal.VersionCode
-import wooga.gradle.version.internal.release.git.GitVersionRepository
-import wooga.gradle.version.internal.release.base.PrefixVersionParser
-
 enum VersionCodeScheme {
-    none({ -> 0}),
-    semverBasic({
-        String version, int offset -> VersionCode.generateSemverVersionCode(version) + offset
-    }),
-    semver({
-        String version, int offset -> VersionCode.generateSemverVersionCode(version, true) + offset
-    }),
-    releaseCountBasic({ Grgit git, int offset ->
-        //Tag strategy here hardcoded for backwards compatibility
-        def versionRepo = GitVersionRepository.fromTagStrategy(git, new PrefixVersionParser("v", false))
-         VersionCode.generateBuildNumberVersionCode(versionRepo, false, offset)
-    }),
-    releaseCount({ Grgit git, int offset ->
-            //Tag strategy here hardcoded for backwards compatibility
-            def versionRepo = GitVersionRepository.fromTagStrategy(git, new PrefixVersionParser("v", false))
-            VersionCode.generateBuildNumberVersionCode(versionRepo, true, offset)
-    })
-
-    @Deprecated
-    //TODO 3.x: remove this generate parameter
-    final Closure<Integer> generate
-
-    VersionCodeScheme(Closure generate) {
-        this.generate = generate
-    }
+    none,
+    semverBasic,
+    semver,
+    releaseCountBasic,
+    releaseCount
 }

--- a/src/main/groovy/wooga/gradle/version/VersionPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/version/VersionPlugin.groovy
@@ -78,11 +78,7 @@ class VersionPlugin implements Plugin<Project> {
             VersionCodeScheme.valueOf(it.trim())
         }))
 
-        // TODO: Refactor once integer / object providers are added on gradle-commons
-        extension.versionCodeOffset.set(project.provider({
-            def rawValue = VersionPluginConventions.versionCodeOffset.getValue(project)
-            Integer.parseInt(rawValue.toString())
-        }))
+        extension.versionCodeOffset.set(VersionPluginConventions.versionCodeOffset.getIntegerValueProvider(project))
         extension.prefix.convention("v")
         return extension
     }

--- a/src/main/groovy/wooga/gradle/version/VersionPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/version/VersionPlugin.groovy
@@ -19,7 +19,6 @@ package wooga.gradle.version
 
 import org.ajoberstar.grgit.Grgit
 import org.eclipse.jgit.errors.RepositoryNotFoundException
-import org.gradle.api.Action
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.logging.Logging
@@ -71,7 +70,7 @@ class VersionPlugin implements Plugin<Project> {
         def extension = project.extensions.create(VersionPluginExtension, EXTENSION_NAME, DefaultVersionPluginExtension, project)
 
         extension.versionScheme.set(VersionPluginConventions.versionScheme.getStringValueProvider(project).map({
-            VersionScheme.valueOf(it.trim())
+            VersionSchemes.valueOf(it.trim())
         }))
 
         extension.versionCodeScheme.set(VersionPluginConventions.versionCodeScheme.getStringValueProvider(project).map({

--- a/src/main/groovy/wooga/gradle/version/VersionPluginConventions.groovy
+++ b/src/main/groovy/wooga/gradle/version/VersionPluginConventions.groovy
@@ -26,7 +26,7 @@ class VersionPluginConventions {
     static final String UNINITIALIZED_VERSION = '0.1.0-dev.0.uninitialized'
 
     static final PropertyLookup version = new PropertyLookup("VERSION_BUILDER_VERSION", "versionBuilder.version", null)
-    static final PropertyLookup versionScheme = new PropertyLookup("VERSION_BUILDER_VERSION_SCHEME", ["versionBuilder.versionScheme", "version.scheme"], VersionScheme.semver)
+    static final PropertyLookup versionScheme = new PropertyLookup("VERSION_BUILDER_VERSION_SCHEME", ["versionBuilder.versionScheme", "version.scheme"], VersionSchemes.semver)
     static final PropertyLookup versionCodeScheme = new PropertyLookup("VERSION_BUILDER_VERSION_CODE_SCHEME", "versionBuilder.versionCodeScheme", VersionCodeScheme.none)
     static final PropertyLookup versionCodeOffset = new PropertyLookup("VERSION_BUILDER_VERSION_CODE_OFFSET", "versionBuilder.versionCodeOffset", 0)
 

--- a/src/main/groovy/wooga/gradle/version/VersionPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/version/VersionPluginExtension.groovy
@@ -35,25 +35,25 @@ trait VersionPluginExtension implements BaseSpec {
     /**
      * @return The version scheme being used by the plugin (such as SemVer2)
      */
-    Property<IVersionScheme> getVersionScheme() {
+    Property<VersionScheme> getVersionScheme() {
         versionScheme
     }
 
-    private final Property<IVersionScheme> versionScheme = objects.property(IVersionScheme)
+    private final Property<VersionScheme> versionScheme = objects.property(VersionScheme)
 
-    void versionScheme(IVersionScheme value) {
+    void versionScheme(VersionScheme value) {
         setVersionScheme(value)
     }
 
-    void versionScheme(Provider<IVersionScheme> value) {
+    void versionScheme(Provider<VersionScheme> value) {
         setVersionScheme(value)
     }
 
-    void setVersionScheme(IVersionScheme value) {
+    void setVersionScheme(VersionScheme value) {
         versionScheme.set(value)
     }
 
-    void setVersionScheme(Provider<IVersionScheme> value) {
+    void setVersionScheme(Provider<VersionScheme> value) {
         versionScheme.set(value)
     }
 
@@ -62,7 +62,7 @@ trait VersionPluginExtension implements BaseSpec {
     }
 
     void setVersionScheme(String value) {
-        versionScheme.set(VersionScheme.valueOf(value.trim()))
+        versionScheme.set(VersionSchemes.valueOf(value.trim()))
     }
 
     /**
@@ -344,7 +344,7 @@ trait VersionPluginExtension implements BaseSpec {
      * @throws org.gradle.api.internal.provider.MissingValueException if there is no configured git repository in this extension.
      * or empty if none of the scheme strategies can be applied to the arguments.
      */
-    Provider<ReleaseVersion> inferVersion(IVersionScheme scheme, Provider<String> stageProvider = this.stage,
+    Provider<ReleaseVersion> inferVersion(VersionScheme scheme, Provider<String> stageProvider = this.stage,
                                           Provider<ChangeScope> scopeProvider = this.scope) {
         def strategyProvider = pickStrategy(scheme, stageProvider)
         strategyProvider.map { strategy ->
@@ -357,7 +357,7 @@ trait VersionPluginExtension implements BaseSpec {
         }
     }
 
-    private Provider<VersionStrategy> pickStrategy(IVersionScheme scheme, Provider<String> stageProvider) {
+    private Provider<VersionStrategy> pickStrategy(VersionScheme scheme, Provider<String> stageProvider) {
         return git.map {
             new GitStrategyPicker(it).pickStrategy(scheme, stageProvider.orNull)
         }.orElse( providers.provider{

--- a/src/main/groovy/wooga/gradle/version/VersionPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/version/VersionPluginExtension.groovy
@@ -26,7 +26,7 @@ import wooga.gradle.version.internal.GitStrategyPicker
 import wooga.gradle.version.internal.release.base.ReleaseVersion
 import wooga.gradle.version.internal.release.base.VersionStrategy
 import wooga.gradle.version.internal.release.git.GitVersionRepository
-import wooga.gradle.version.internal.release.git.PrefixTagStrategy
+import wooga.gradle.version.internal.release.base.PrefixVersionParser
 import wooga.gradle.version.internal.release.semver.ChangeScope
 import wooga.gradle.version.internal.release.semver.VersionInferenceParameters
 
@@ -316,7 +316,7 @@ trait VersionPluginExtension implements BaseSpec {
     }
 
     Provider<GitVersionRepository> versionRepo = git.map {
-        Grgit it -> GitVersionRepository.fromTagStrategy(it, new PrefixTagStrategy(prefix.get(), true))
+        Grgit it -> GitVersionRepository.fromTagStrategy(it, new PrefixVersionParser(prefix.get(), true))
     }
 
     final Provider<ReleaseStage> releaseStage = providers.provider { ->

--- a/src/main/groovy/wooga/gradle/version/VersionScheme.java
+++ b/src/main/groovy/wooga/gradle/version/VersionScheme.java
@@ -13,7 +13,7 @@ import java.util.Optional;
  * A default strategy can also be provided.
  */
 //This has to be a java class (not groovy) because groovy 2 doesn't support java 8 default interface methods.
-public interface IVersionScheme { //TODO: Rename to VersionScheme when breaking change
+public interface VersionScheme { //TODO: Rename to VersionScheme when breaking change
     VersionStrategy getDevelopment();
     VersionStrategy getSnapshot();
     VersionStrategy getPreRelease();

--- a/src/main/groovy/wooga/gradle/version/VersionSchemes.groovy
+++ b/src/main/groovy/wooga/gradle/version/VersionSchemes.groovy
@@ -26,13 +26,12 @@ import wooga.gradle.version.strategies.opinion.SemverV2WithDefaultStrategies
 import wooga.gradle.version.strategies.opinion.UpmStrategies
 import wooga.gradle.version.strategies.opinion.WdkNuGetStrategies
 
-//TODO: 3.x Rename to VersionSchemes when breaking change
 /**
  * Version schemes available for use with this plugin.
  * Each scheme consists of at least 4 strategies (development, snapshot, pre-release and final)
  * plus additional strategies if so desired. Check IVersionScheme for more details.
  */
-enum VersionScheme implements IVersionScheme {
+enum VersionSchemes implements VersionScheme {
     semver(LegacyNuGetStrategies.DEVELOPMENT,
             LegacyNuGetStrategies.SNAPSHOT,
             LegacyNuGetStrategies.PRE_RELEASE,
@@ -72,7 +71,7 @@ enum VersionScheme implements IVersionScheme {
     final List<VersionStrategy> strategies
     final VersionStrategy defaultStrategy
 
-    VersionScheme(VersionStrategy development, VersionStrategy snapshot, VersionStrategy preRelease, VersionStrategy finalStrategy, SemVerStrategy... others) {
+    VersionSchemes(VersionStrategy development, VersionStrategy snapshot, VersionStrategy preRelease, VersionStrategy finalStrategy, SemVerStrategy... others) {
         this.development = development
         this.snapshot = snapshot
         this.preRelease = preRelease

--- a/src/main/groovy/wooga/gradle/version/internal/DefaultVersionPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/version/internal/DefaultVersionPluginExtension.groovy
@@ -52,7 +52,7 @@ class DefaultVersionPluginExtension implements VersionPluginExtension {
         versionCode = versionCodeScheme.map({
             VersionCodeScheme scheme -> VersionCode.Schemes
                     .fromExternal(scheme)
-                    .versionCodeFor(this.version.map { it.version }, versionRepo, versionCodeOffset.getOrElse(0))
+                    .versionCodeFor(this.version.map { it.version }.orNull, versionRepo.orNull, versionCodeOffset.getOrElse(0))
         }.memoize())
 
         // It's development if the development strategy contains the set `stage` OR

--- a/src/main/groovy/wooga/gradle/version/internal/GitStrategyPicker.groovy
+++ b/src/main/groovy/wooga/gradle/version/internal/GitStrategyPicker.groovy
@@ -1,7 +1,7 @@
 package wooga.gradle.version.internal
 
 import org.ajoberstar.grgit.Grgit
-import wooga.gradle.version.IVersionScheme
+import wooga.gradle.version.VersionScheme
 import wooga.gradle.version.internal.release.base.DefaultVersionStrategy
 import wooga.gradle.version.internal.release.base.VersionStrategy
 
@@ -25,7 +25,7 @@ class GitStrategyPicker {
      * If null, the stage to be used in execution will depend if a fallback is set in the selected strategy itself.
      * @return Selected VersionStrategy or null if no strategy matches.
      */
-    VersionStrategy pickStrategy(IVersionScheme scheme, @Nullable String stage) {
+    VersionStrategy pickStrategy(VersionScheme scheme, @Nullable String stage) {
         return pickStrategy(scheme.strategies, scheme.defaultStrategy, stage)
     }
 

--- a/src/main/groovy/wooga/gradle/version/internal/VersionCode.groovy
+++ b/src/main/groovy/wooga/gradle/version/internal/VersionCode.groovy
@@ -18,10 +18,6 @@
 
 package wooga.gradle.version.internal
 
-import groovy.transform.stc.ClosureParams
-import groovy.transform.stc.SimpleType
-import org.ajoberstar.grgit.Grgit
-import org.gradle.api.provider.Provider
 import wooga.gradle.version.VersionCodeScheme
 import wooga.gradle.version.internal.release.git.GitVersionRepository
 
@@ -54,16 +50,13 @@ class VersionCode {
             this.generator = generator
         }
 
-        //TODO: These providers can be simple types.
-        int versionCodeFor(Provider<String> versionProvider, Provider<GitVersionRepository> gitProvider, int offset) {
+        int versionCodeFor(String version, GitVersionRepository git, int offset) {
             if(generator.parameterTypes.length == 0) {
                 return this.generator.call()
             }
             if(generator.parameterTypes[0] == String) {
-                def version = versionProvider.get()
                 return this.generator.call(version, offset)
             } else {
-                def git = gitProvider.get()
                 return this.generator.call(git, offset)
             }
         }

--- a/src/main/groovy/wooga/gradle/version/internal/release/base/PrefixVersionParser.groovy
+++ b/src/main/groovy/wooga/gradle/version/internal/release/base/PrefixVersionParser.groovy
@@ -16,30 +16,29 @@
  *
  */
 
-package wooga.gradle.version.internal.release.git
+package wooga.gradle.version.internal.release.base
 
 import com.github.zafarkhaja.semver.ParseException
 import com.github.zafarkhaja.semver.Version
-import org.ajoberstar.grgit.Tag
 import org.apache.commons.lang3.StringUtils
 
-class PrefixTagStrategy implements TagStrategy {
+class PrefixVersionParser implements VersionParser {
 
     final String prefix
     final boolean tryParseWoutPrefix
 
-    PrefixTagStrategy(String prefix, boolean tryParseWoutPrefix) {
+    PrefixVersionParser(String prefix, boolean tryParseWoutPrefix) {
         this.prefix = prefix
         this.tryParseWoutPrefix = tryParseWoutPrefix
     }
 
     @Override
-    Version parseTag(Tag tag) {
+    Version parse(String rawVersion) {
         try {
-            if (tryParseWoutPrefix && !tag.name.startsWith(prefix)) {
-                return Version.valueOf(tag.name)
-            } else if (tag.name.startsWith(prefix)) {
-                return Version.valueOf(StringUtils.removeStart(tag.name, prefix))
+            if (tryParseWoutPrefix && !rawVersion.startsWith(prefix)) {
+                return Version.valueOf(rawVersion)
+            } else if (rawVersion.startsWith(prefix)) {
+                return Version.valueOf(StringUtils.removeStart(rawVersion, prefix))
             }
         } catch (ParseException ignore) {
         }

--- a/src/main/groovy/wooga/gradle/version/internal/release/base/VersionParser.groovy
+++ b/src/main/groovy/wooga/gradle/version/internal/release/base/VersionParser.groovy
@@ -1,0 +1,8 @@
+package wooga.gradle.version.internal.release.base
+
+import com.github.zafarkhaja.semver.Version
+import org.ajoberstar.grgit.Tag
+
+interface VersionParser {
+    Version parse(String rawVersion)
+}

--- a/src/main/groovy/wooga/gradle/version/internal/release/git/TagStrategy.groovy
+++ b/src/main/groovy/wooga/gradle/version/internal/release/git/TagStrategy.groovy
@@ -1,9 +1,0 @@
-package wooga.gradle.version.internal.release.git
-
-import com.github.zafarkhaja.semver.Version
-import org.ajoberstar.grgit.Tag
-
-interface TagStrategy {
-    //TODO: decouple this from git by making it accept a String with a tag name instead of Tag
-    Version parseTag(Tag tag)
-}

--- a/src/main/groovy/wooga/gradle/version/strategies/NewSemverV1Strategies.groovy
+++ b/src/main/groovy/wooga/gradle/version/strategies/NewSemverV1Strategies.groovy
@@ -17,7 +17,7 @@
 
 package wooga.gradle.version.strategies
 
-import wooga.gradle.version.IVersionScheme
+
 import wooga.gradle.version.ReleaseStage
 import wooga.gradle.version.internal.release.opinion.Strategies
 import wooga.gradle.version.internal.release.semver.*

--- a/src/main/groovy/wooga/gradle/version/strategies/NewSemverV2Strategies.groovy
+++ b/src/main/groovy/wooga/gradle/version/strategies/NewSemverV2Strategies.groovy
@@ -17,7 +17,7 @@
 
 package wooga.gradle.version.strategies
 
-import wooga.gradle.version.IVersionScheme
+import wooga.gradle.version.VersionScheme
 import wooga.gradle.version.ReleaseStage
 import wooga.gradle.version.internal.release.opinion.Strategies
 import wooga.gradle.version.internal.release.semver.SemVerStrategy
@@ -160,7 +160,7 @@ final class NewSemverV2Strategies {
                                     Strategies.PreRelease.COUNT_COMMITS_SINCE_ANY),
     )
 
-    static final IVersionScheme scheme = new IVersionScheme() {
+    static final VersionScheme scheme = new VersionScheme() {
         final SemVerStrategy development = DEVELOPMENT
         final SemVerStrategy snapshot = SNAPSHOT
         final SemVerStrategy preRelease = PRE_RELEASE

--- a/src/test/groovy/wooga/gradle/version/NewSemverV1StrategySpec.groovy
+++ b/src/test/groovy/wooga/gradle/version/NewSemverV1StrategySpec.groovy
@@ -9,7 +9,7 @@ import wooga.gradle.version.strategies.NewSemverV1Strategies
 class NewSemverV1StrategySpec extends ProjectSpec {
 
     public static final String PLUGIN_NAME = 'net.wooga.version'
-    static final IVersionScheme semverV1Scheme = new IVersionScheme() {
+    static final VersionScheme semverV1Scheme = new VersionScheme() {
         final SemVerStrategy development = NewSemverV1Strategies.DEVELOPMENT
         final SemVerStrategy snapshot = NewSemverV1Strategies.SNAPSHOT
         final SemVerStrategy preRelease = NewSemverV1Strategies.PRE_RELEASE

--- a/src/test/groovy/wooga/gradle/version/NewSemverV2StrategySpec.groovy
+++ b/src/test/groovy/wooga/gradle/version/NewSemverV2StrategySpec.groovy
@@ -11,7 +11,7 @@ class NewSemverV2StrategySpec extends ProjectSpec {
 
     public static final String PLUGIN_NAME = 'net.wooga.version'
 
-    static final IVersionScheme semverV2Scheme = new IVersionScheme() {
+    static final VersionScheme semverV2Scheme = new VersionScheme() {
         final SemVerStrategy development = NewSemverV2Strategies.DEVELOPMENT
         final SemVerStrategy snapshot = NewSemverV2Strategies.SNAPSHOT
         final SemVerStrategy preRelease = NewSemverV2Strategies.PRE_RELEASE

--- a/src/test/groovy/wooga/gradle/version/VersionPluginSpec.groovy
+++ b/src/test/groovy/wooga/gradle/version/VersionPluginSpec.groovy
@@ -19,7 +19,6 @@ package wooga.gradle.version
 
 import nebula.test.ProjectSpec
 import org.ajoberstar.grgit.Grgit
-import org.gradle.cache.internal.VersionStrategy
 import spock.lang.Ignore
 import spock.lang.Unroll
 import wooga.gradle.version.internal.ToStringProvider
@@ -993,12 +992,12 @@ class VersionPluginSpec extends ProjectSpec {
 
         where:
         nearestNormal | nearestAny | distance | stage      | scope | scheme                | branchName | prefixTag | expectedVersion
-        '1.0.0'       | _          | 1        | "ci"       | _     | VersionScheme.semver2 | "master"   | true      | "1.1.0-master.1"
-        '1.0.0'       | _          | 1        | "ci"       | _     | VersionScheme.semver2 | "master"   | false     | "1.1.0-master.1"
-        '1.0.0'       | _          | 1        | "snapshot" | _     | VersionScheme.semver  | "master"   | true      | "1.0.1-master00001"
-        '1.0.0'       | _          | 1        | "snapshot" | _     | VersionScheme.semver  | "master"   | false     | "1.0.1-master00001"
-        _             | _          | 1        | "ci"       | _     | VersionScheme.semver2 | "master"   | false     | "0.1.0-master.2"
-        _             | _          | 1        | "snapshot" | _     | VersionScheme.semver  | "master"   | false     | "0.0.1-master00002"
+        '1.0.0'       | _          | 1        | "ci"       | _     | VersionSchemes.semver2 | "master" | true  | "1.1.0-master.1"
+        '1.0.0'       | _          | 1        | "ci"       | _     | VersionSchemes.semver2 | "master" | false | "1.1.0-master.1"
+        '1.0.0'       | _          | 1        | "snapshot" | _     | VersionSchemes.semver  | "master" | true  | "1.0.1-master00001"
+        '1.0.0'       | _          | 1        | "snapshot" | _     | VersionSchemes.semver  | "master" | false | "1.0.1-master00001"
+        _             | _          | 1        | "ci"       | _     | VersionSchemes.semver2 | "master" | false | "0.1.0-master.2"
+        _             | _          | 1        | "snapshot" | _     | VersionSchemes.semver  | "master" | false | "0.0.1-master00002"
         nearestAnyTitle = (nearestAny == _) ? "unset" : nearestAny
         scopeTitle = (scope == _) ? "unset" : scope
         tagPrefix = (prefixTag) ? "v" : ""

--- a/src/test/groovy/wooga/gradle/version/internal/VersionCodeSpec.groovy
+++ b/src/test/groovy/wooga/gradle/version/internal/VersionCodeSpec.groovy
@@ -22,7 +22,7 @@ import org.ajoberstar.grgit.Grgit
 import spock.lang.Specification
 import spock.lang.Unroll
 import wooga.gradle.version.internal.release.git.GitVersionRepository
-import wooga.gradle.version.internal.release.git.PrefixTagStrategy
+import wooga.gradle.version.internal.release.base.PrefixVersionParser
 
 class VersionCodeSpec extends Specification {
 
@@ -138,7 +138,7 @@ class VersionCodeSpec extends Specification {
         1                  | 1                      | 0      | true
         3                  | 2                      | 100    | true
         3                  | 5                      | 10     | true
-        tagStrategy = new PrefixTagStrategy("v", false)
+        tagStrategy = new PrefixVersionParser("v", false)
         message = "when number of normal tags: ${numberOfNormalTags} prerelease tags: ${numberOfPrereleaseTags} and offset: ${offset}"
         expectedValue = numberOfNormalTags + offset + (countPrerelease ? numberOfPrereleaseTags : 0) + 1
     }
@@ -183,6 +183,6 @@ class VersionCodeSpec extends Specification {
         "develop" | 0      | true            | 5
         "develop" | 30     | false           | 32
         "develop" | 40     | true            | 45
-        tagStrategy = new PrefixTagStrategy("v", false)
+        tagStrategy = new PrefixVersionParser("v", false)
     }
 }


### PR DESCRIPTION
## Description

Smaller changes that are too small for their own single PR. Described below:

* Removes `generate` param from VersionCodeScheme. It wasn't being used internally anymore, but class is not internal, so this was being kept for backwards compatibility sake.

* Renames `TagStrategy`and related classes to `VersionParser` and similar. There is a meaning overload in the `Strategy` word, as its also used to describe the many kinds of versions (semver, semver2, etc). Parser describes better what this class family does (*parse* a raw tag name to a internal version object).
   * Coalesces old `MarkerTagStrategy` and `TagStrategy` into a single `PrefixVersionParser`, as both dealt with prefixes.
   * Also, `VersionParser` now receives a String instead of a `Tag`, to make it detached from git concepts.
   
   
Based on #58, please merge that first.

## Changes
* ![REMOVE] Deprecated `VersionCodeScheme.generate` function. This functionality is now dealt by the internal `VersionCode.Scheme` class.
* ![CHANGE] Coalesces old `MarkerTagStrategy` and `TagStrategy` into a single `PrefixVersionParser`




[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"
