### PR TITLE
normalizes setScope(string) to be case unsensitive

### DIFF
--- a/src/integrationTest/groovy/wooga/gradle/version/VersionPluginMultiProjectIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/version/VersionPluginMultiProjectIntegrationSpec.groovy
@@ -53,7 +53,7 @@ class VersionPluginMultiProjectIntegrationSpec extends VersionIntegrationSpec {
                     ${applyPlugin(VersionPlugin)}
                     versionBuilder.prefix = ${wrapValueBasedOnType(it.prefix, String)}
                     versionBuilder.stage.set(${wrapValueBasedOnType(it.stage, String)})
-                    versionBuilder.scope = provider{ ${wrapValueBasedOnType(it.scope, "ChangeScope")} }
+                    versionBuilder.scope = ${wrapValueBasedOnType(it.scope, String)}
                     versionBuilder.versionScheme = ${wrapValueBasedOnType(it.versionScheme, String)}
                     versionBuilder.versionCodeScheme = ${wrapValueBasedOnType(it.versionCodeScheme, String)}
 
@@ -87,7 +87,7 @@ class VersionPluginMultiProjectIntegrationSpec extends VersionIntegrationSpec {
                 prefix: "proj1-",
                 nearestNormal: "0.0.1",
                 stage: "final",
-                scope: ChangeScope.MINOR,
+                scope: "MINOR",
                 versionScheme: "semver",
                 versionCodeScheme: VersionCodeSchemes.releaseCountBasic,
                 newVersion: "0.1.0",
@@ -99,7 +99,7 @@ class VersionPluginMultiProjectIntegrationSpec extends VersionIntegrationSpec {
                 prefix: "proj2-",
                 nearestNormal: "1.0.0",
                 stage: "rc",
-                scope: ChangeScope.MAJOR,
+                scope: 'major',
                 versionScheme: "semver2",
                 versionCodeScheme: VersionCodeSchemes.semver,
                 newVersion: "2.0.0-rc.1",

--- a/src/main/groovy/wooga/gradle/version/VersionPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/version/VersionPluginExtension.groovy
@@ -251,7 +251,7 @@ trait VersionPluginExtension implements BaseSpec {
     }
 
     void setScope(String scope) {
-        this.scope.set(ChangeScope.valueOf(scope.trim()))
+        this.scope.set(ChangeScope.valueOf(scope.trim().toUpperCase()))
     }
 
     private final Property<String> prefix = objects.property(String)


### PR DESCRIPTION
## Description
FIxes bug where `versionBuilder.setScope` wont recognize a scope when its used with a lower-case string. 

## Changes
* ![FIX] `versionBuilder.setScope` now recognizes both upper and lower cases.



[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"
