### PR TITLE
Make is<Stage> public

### DIFF
--- a/src/test/groovy/wooga/gradle/version/VersionPluginSpec.groovy
+++ b/src/test/groovy/wooga/gradle/version/VersionPluginSpec.groovy
@@ -19,6 +19,7 @@ package wooga.gradle.version
 
 import nebula.test.ProjectSpec
 import org.ajoberstar.grgit.Grgit
+import org.gradle.api.provider.Provider
 import spock.lang.Ignore
 import spock.lang.IgnoreIf
 import spock.lang.Unroll
@@ -1092,4 +1093,30 @@ class VersionPluginSpec extends ProjectSpec {
         propertyName             | version
         "versionBuilder.version" | "1.2.3"
     }
+
+    def "#stageProperty extension property returns expected value on given #stage"() {
+        given:
+        project.plugins.apply(PLUGIN_NAME)
+        def extension = project.extensions.getByType(VersionPluginExtension)
+
+        when:
+        extension.stage = stage
+
+        then:
+        def stageProvider = extension.properties[stageProperty] as Provider<Boolean>
+        stageProvider.get() == true
+        (allStageProperties - [stageProperty]).each { propName ->
+            assert extension.properties[propName].get() == false, "$propName should return falses"
+        }
+
+        where:
+        stage      | stageProperty
+        "snapshot" | "isSnapshot"
+        "dev"      | "isDevelopment"
+        "rc"       | "isPrerelease"
+        "final"    | "isFinal"
+
+        allStageProperties = ["isSnapshot", "isDevelopment", "isPrerelease", "isFinal"]
+    }
+
 }


### PR DESCRIPTION
## Description
Previous major `is<Stage>` extension methods were not matching 100% the release stage so they were put to private and only were used in the internals of the extension. 

However, those methods are still useful, and are being an annoying source breaks elsewhere. Adding them back with a correct implementation gives us back some useful methods, and reduce pains on the 2.x-3.x jump.

## Changes
* ![ADD] `isSnapshot`, `isDevelopment`, `isPrerelease` and `isFinal` extension methods.



[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"
