### PR TITLE
Memoize the project version provider

### DIFF
--- a/src/main/groovy/wooga/gradle/version/VersionPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/version/VersionPlugin.groovy
@@ -53,9 +53,9 @@ class VersionPlugin implements Plugin<Project> {
     }
 
     private static void setProjectVersion(Project project, VersionPluginExtension extension) {
-        def sharedVersion = new ToStringProvider(extension.version.map({ it.version }))
+        def versionProvider = new ToStringProvider(extension.version.map({ it.version }.memoize()))
         applyOnCurrentAndSubProjects(project) { Project prj ->
-            prj.setVersion(sharedVersion)
+            prj.setVersion(versionProvider)
             def versionCodeExt = project.extensions.findByName(VERSION_CODE_EXTENSION_NAME) as VersionCodeExtension
             if(!versionCodeExt) {
                 versionCodeExt = DefaultVersionCodeExtension.empty(prj, VERSION_CODE_EXTENSION_NAME)


### PR DESCRIPTION
## Description
Memoize the project version provider, which was currently being invoked... repeatedly. 

## Changes
* ![ADD] `VersionPlugin` now memoizes the version provider set on the projects

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"
